### PR TITLE
API: Improving file and folder naming to achieve safer concurrency.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,7 @@ dependencies = [
  "colored",
  "deadline",
  "futures",
+ "hex",
  "indexmap 2.7.0",
  "itertools 0.12.1",
  "mockall",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,7 @@ dependencies = [
  "clap",
  "colored",
  "crossterm",
+ "glob",
  "indexmap 2.7.0",
  "nix",
  "num_cpus",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,6 +17,9 @@ test_targets = ["snarkvm/test_targets"]
 [dependencies.anstyle]
 version = "1"
 
+[dependencies.glob]
+version = "0.3"
+
 [dependencies.anyhow]
 version = "1.0.79"
 

--- a/cli/src/commands/clean.rs
+++ b/cli/src/commands/clean.rs
@@ -46,8 +46,8 @@ impl Clean {
     pub fn remove_all(&self, keep_state: bool) -> Result<String> {
         // Determine the ledger path
         let ledger_path = match &self.path {
-            Some(path) => custom_ledger_dir(self.network, keep_state, path.clone()),
-            None => amareleo_ledger_dir(self.network, keep_state),
+            Some(path) => custom_ledger_dir(self.network, keep_state, "0", path.clone()),
+            None => amareleo_ledger_dir(self.network, keep_state, "0"),
         };
 
         // Remove the current proposal cache file, if it exists.

--- a/cli/src/commands/clean.rs
+++ b/cli/src/commands/clean.rs
@@ -59,7 +59,7 @@ impl Clean {
 
     /// Removes the specified ledger from storage.
     pub(crate) fn remove_proposal_cache(network: u16, keep_state: bool, path: PathBuf) -> Result<()> {
-        let storage_mode = amareleo_storage_mode(network, keep_state, Some(path));
+        let storage_mode = amareleo_storage_mode(path);
 
         // Remove the current proposal cache file, if it exists.
         let proposal_cache_path = proposal_cache_path(network, keep_state, &storage_mode);

--- a/cli/src/commands/clean.rs
+++ b/cli/src/commands/clean.rs
@@ -13,7 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use amareleo_node::bft::helpers::{amareleo_ledger_dir, amareleo_storage_mode, custom_ledger_dir, proposal_cache_path};
+use amareleo_node::bft::helpers::{
+    DEFAULT_FILE_TAG,
+    amareleo_ledger_dir,
+    amareleo_storage_mode,
+    custom_ledger_dir,
+    proposal_cache_path,
+};
 
 use anyhow::{Result, bail};
 use clap::Parser;
@@ -58,10 +64,12 @@ impl Clean {
     }
 
     pub fn remove_all(&self, keep_state: bool) -> Result<()> {
+        let file_tag = if keep_state { DEFAULT_FILE_TAG } else { "*" };
+
         // Determine the ledger path
         let pattern = match &self.path {
-            Some(path) => custom_ledger_dir(self.network, keep_state, "*", path.clone()),
-            None => amareleo_ledger_dir(self.network, keep_state, "*"),
+            Some(path) => custom_ledger_dir(self.network, keep_state, file_tag, path.clone()),
+            None => amareleo_ledger_dir(self.network, keep_state, file_tag),
         };
 
         if let Some(pattern_str) = pattern.to_str() {

--- a/cli/src/commands/clean.rs
+++ b/cli/src/commands/clean.rs
@@ -51,21 +51,21 @@ impl Clean {
         };
 
         // Remove the current proposal cache file, if it exists.
-        Self::remove_proposal_cache(self.network, keep_state, ledger_path.clone())?;
+        Self::remove_proposal_cache(ledger_path.clone())?;
 
         // Remove the specified ledger from storage.
-        Self::remove_ledger(keep_state, ledger_path)
+        Self::remove_ledger(ledger_path)
     }
 
     /// Removes the specified ledger from storage.
-    pub(crate) fn remove_proposal_cache(network: u16, keep_state: bool, path: PathBuf) -> Result<()> {
+    pub(crate) fn remove_proposal_cache(path: PathBuf) -> Result<()> {
         let storage_mode = amareleo_storage_mode(path);
 
         // Remove the current proposal cache file, if it exists.
-        let proposal_cache_path = proposal_cache_path(network, keep_state, &storage_mode);
-        if proposal_cache_path.exists() {
-            if let Err(err) = std::fs::remove_file(&proposal_cache_path) {
-                bail!("Failed to remove the current proposal cache file at {}: {err}", proposal_cache_path.display());
+        let cache_path = proposal_cache_path(&storage_mode)?;
+        if cache_path.exists() {
+            if let Err(err) = std::fs::remove_file(&cache_path) {
+                bail!("Failed to remove the current proposal cache file at {}: {err}", cache_path.display());
             }
         }
 
@@ -73,26 +73,21 @@ impl Clean {
     }
 
     /// Removes the specified ledger from storage.
-    pub(crate) fn remove_ledger(keep_state: bool, path: PathBuf) -> Result<String> {
+    pub(crate) fn remove_ledger(path: PathBuf) -> Result<String> {
         // Prepare the path string.
         let path_string = format!("(in \"{}\")", path.display()).dimmed();
-
-        let store_desc: &str = if keep_state { "persistent" } else { "temporary" };
 
         // Check if the path to the ledger exists in storage.
         if path.exists() {
             // Remove the ledger files from storage.
             match std::fs::remove_dir_all(&path) {
-                Ok(_) => Ok(format!("✅ Cleaned the {store_desc} amareleo node storage {path_string}")),
+                Ok(_) => Ok(format!("✅ Cleaned the amareleo node storage {path_string}")),
                 Err(error) => {
-                    bail!(
-                        "Failed to remove the {store_desc} amareleo node storage {path_string}\n{}",
-                        error.to_string().dimmed()
-                    )
+                    bail!("Failed to remove the amareleo node storage {path_string}\n{}", error.to_string().dimmed())
                 }
             }
         } else {
-            Ok(format!("✅ No {store_desc} amareleo node storage was found {path_string}"))
+            Ok(format!("✅ No amareleo node storage was found {path_string}"))
         }
     }
 }

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -289,7 +289,7 @@ impl Start {
         }
 
         // Initialize the storage mode.
-        let storage_mode = amareleo_storage_mode(self.network, self.keep_state, Some(ledger_path));
+        let storage_mode = amareleo_storage_mode(ledger_path);
         let validator = Validator::new(rest_ip, self.rest_rps, account, genesis, self.keep_state, storage_mode, shutdown.clone()).await?;
         // Initialize the node.
         Ok(Arc::new(validator))

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -283,8 +283,8 @@ impl Start {
 
         if !self.keep_state {
             // Remove old ledger state
-            Clean::remove_proposal_cache(self.network, self.keep_state, ledger_path.clone())?;
-            let res_text = Clean::remove_ledger(self.keep_state, ledger_path.clone())?;
+            Clean::remove_proposal_cache(ledger_path.clone())?;
+            let res_text = Clean::remove_ledger(ledger_path.clone())?;
             println!("{res_text}\n");
         }
 

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -33,7 +33,7 @@ use amareleo_chain_resources::{
 };
 use amareleo_node::{
     Validator,
-    bft::helpers::{amareleo_ledger_dir, amareleo_storage_mode, custom_ledger_dir},
+    bft::helpers::{amareleo_ledger_dir, amareleo_storage_mode, custom_ledger_dir, endpoint_file_tag},
 };
 
 use snarkvm::{
@@ -157,7 +157,7 @@ impl Start {
     fn parse_development(&mut self) -> Result<()> {
         // If the REST IP is not already specified set the REST IP to `3030`.
         if self.rest.is_none() {
-            self.rest = Some(SocketAddr::from_str(&format!("0.0.0.0:{}", 3030)).unwrap());
+            self.rest = Some(SocketAddr::from_str("0.0.0.0:3030").unwrap());
         }
 
         Ok(())
@@ -275,10 +275,13 @@ impl Start {
             metrics::initialize_metrics(self.metrics_ip);
         }
 
+        // Get a unique tag for this endpoint
+        let tag = endpoint_file_tag::<N>(&rest_ip)?;
+
         // Determine the ledger path
         let ledger_path = match &self.storage {
-            Some(path) => custom_ledger_dir(self.network, self.keep_state, path.clone()),
-            None => amareleo_ledger_dir(self.network, self.keep_state),
+            Some(path) => custom_ledger_dir(self.network, self.keep_state, &tag,path.clone()),
+            None => amareleo_ledger_dir(self.network, self.keep_state, &tag),
         };
 
         if !self.keep_state {

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -109,7 +109,7 @@ impl Start {
         let shutdown: Arc<AtomicBool> = Default::default();
 
         // Initialize the logger.
-        crate::helpers::initialize_logger(self.verbosity, self.logfile.clone(), shutdown.clone());
+        crate::helpers::initialize_logger(self.verbosity, self.logfile.clone(), true, shutdown.clone());
         // Initialize the runtime.
         Self::runtime().block_on(async move {
             // Clone the configurations.

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -152,12 +152,16 @@ impl Start {
         let log_path = match self.logfile.clone() {
             Some(path) => path,
             None => {
-                // Get a unique tag for this endpoint
+                // Get a unique tag for the specified rest endpoint
+                // Even if --keep-state is set, log files will
+                // always get a unique tag since these all go to
+                // the tmp folder by default, hence causing multiple
+                // instances to write to the same file.
                 let rest_ip = self.rest.or_else(|| Some("0.0.0.0:3030".parse().unwrap()));
                 let tag = match self.network {
-                    MainnetV0::ID => endpoint_file_tag::<MainnetV0>(&rest_ip)?,
-                    TestnetV0::ID => endpoint_file_tag::<TestnetV0>(&rest_ip)?,
-                    CanaryV0::ID => endpoint_file_tag::<CanaryV0>(&rest_ip)?,
+                    MainnetV0::ID => endpoint_file_tag::<MainnetV0>(false, &rest_ip)?,
+                    TestnetV0::ID => endpoint_file_tag::<TestnetV0>(false, &rest_ip)?,
+                    CanaryV0::ID => endpoint_file_tag::<CanaryV0>(false, &rest_ip)?,
                     _ => panic!("Invalid network ID specified"),
                 };
 
@@ -308,7 +312,7 @@ impl Start {
         }
 
         // Get a unique tag for this endpoint
-        let tag = endpoint_file_tag::<N>(&rest_ip)?;
+        let tag = endpoint_file_tag::<N>(self.keep_state, &rest_ip)?;
 
         // Determine the ledger path
         let ledger_path = match &self.storage {

--- a/node/bft/Cargo.toml
+++ b/node/bft/Cargo.toml
@@ -22,6 +22,9 @@ test_targets = ["snarkvm/test_targets"]
 [dependencies.aleo-std]
 workspace = true
 
+[dependencies.hex]
+version = "0.4"
+
 [dependencies.anyhow]
 version = "1.0.79"
 

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -1614,7 +1614,7 @@ mod tests {
 
         // Initialize the BFT without bootup.
         let account = Account::try_from(private_keys[0])?;
-        let ledger_dir = amareleo_ledger_dir(1, true);
+        let ledger_dir = amareleo_ledger_dir(1, true, "0");
         let storage_mode = amareleo_storage_mode(ledger_dir);
         let bft = BFT::new(account.clone(), storage, true, storage_mode.clone(), ledger.clone())?;
 

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -898,7 +898,7 @@ mod tests {
     use crate::{
         BFT,
         MAX_LEADER_CERTIFICATE_DELAY_IN_SECS,
-        helpers::{Storage, amareleo_storage_mode},
+        helpers::{Storage, amareleo_ledger_dir, amareleo_storage_mode},
     };
 
     use amareleo_chain_account::Account;
@@ -1614,7 +1614,9 @@ mod tests {
 
         // Initialize the BFT without bootup.
         let account = Account::try_from(private_keys[0])?;
-        let bft = BFT::new(account.clone(), storage, true, amareleo_storage_mode(1, true, None), ledger.clone())?;
+        let ledger_dir = amareleo_ledger_dir(1, true);
+        let storage_mode = amareleo_storage_mode(ledger_dir);
+        let bft = BFT::new(account.clone(), storage, true, storage_mode.clone(), ledger.clone())?;
 
         // Insert a mock DAG in the BFT without bootup.
         *bft.dag.write() = crate::helpers::dag::test_helpers::mock_dag_with_modified_last_committed_round(0);
@@ -1639,8 +1641,7 @@ mod tests {
         let bootup_storage = Storage::new(ledger.clone(), Arc::new(BFTMemoryService::new()), max_gc_rounds);
 
         // Initialize a new instance of BFT with bootup.
-        let bootup_bft =
-            BFT::new(account, bootup_storage.clone(), true, amareleo_storage_mode(1, true, None), ledger.clone())?;
+        let bootup_bft = BFT::new(account, bootup_storage.clone(), true, storage_mode.clone(), ledger.clone())?;
 
         // Sync the BFT DAG at bootup.
         bootup_bft.sync_bft_dag_at_bootup(pre_shutdown_certificates.clone()).await;

--- a/node/bft/src/helpers/ledger_files.rs
+++ b/node/bft/src/helpers/ledger_files.rs
@@ -28,16 +28,21 @@ const PROPOSAL_CACHE_TAG: &str = "-proposal-cache-";
 const LOG_STD_FILE: &str = "amareleo-chain";
 const LOG_TMP_FILE: &str = "amareleo-chain-tmp";
 
-/// A string derived from the hash of the REST endpoint, giving us a unique filename per endpoint.
-pub fn endpoint_file_tag<N: Network>(endpoint: &Option<SocketAddr>) -> Result<String> {
-    let default: SocketAddr = "0.0.0.0:3030".parse().unwrap();
+pub const DEFAULT_FILE_TAG: &str = "0";
 
-    // Initialize the hasher.
+/// A string derived from the hash of the REST endpoint, giving us a unique filename per endpoint.
+pub fn endpoint_file_tag<N: Network>(force_default: bool, endpoint: &Option<SocketAddr>) -> Result<String> {
+    if force_default {
+        return Ok(DEFAULT_FILE_TAG.to_string());
+    }
+
     if let Some(socket) = endpoint {
+        let default: SocketAddr = "0.0.0.0:3030".parse().unwrap();
         if *socket == default {
-            return Ok("0".to_string());
+            return Ok(DEFAULT_FILE_TAG.to_string());
         }
 
+        // Initialize the hasher.
         let hasher = snarkvm::console::algorithms::BHP256::<N>::setup("aleo.dev.block")?;
         let endpoint_str = socket.to_string();
         let bits = endpoint_str.to_bits_le();
@@ -47,7 +52,7 @@ pub fn endpoint_file_tag<N: Network>(endpoint: &Option<SocketAddr>) -> Result<St
         return Ok(hash_str[..hash_str.len().min(8)].to_string());
     }
 
-    Ok("0".to_string())
+    Ok(DEFAULT_FILE_TAG.to_string())
 }
 
 /// Returns the ledger dir for the given base path

--- a/node/bft/src/helpers/ledger_files.rs
+++ b/node/bft/src/helpers/ledger_files.rs
@@ -1,0 +1,127 @@
+// Copyright 2024 Aleo Network Foundation
+// This file is part of the snarkOS library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use snarkvm::{
+    console::{algorithms::Hash, network::Network},
+    prelude::{Result, ToBits, ToBytes, anyhow, bail},
+};
+
+use aleo_std::StorageMode;
+use std::{net::SocketAddr, path::PathBuf};
+
+const LEDGER_STD_DIR: &str = "amareleo-ledger";
+const LEDGER_TMP_DIR: &str = "amareleo-tmp-ledger";
+const LEDGER_DIR_TAG: &str = "-ledger-";
+const PROPOSAL_CACHE_TAG: &str = "-proposal-cache-";
+const LOG_STD_FILE: &str = "amareleo-chain";
+const LOG_TMP_FILE: &str = "amareleo-chain-tmp";
+
+/// A string derived from the hash of the REST endpoint, giving us a unique filename per endpoint.
+pub fn endpoint_file_tag<N: Network>(endpoint: &Option<SocketAddr>) -> Result<String> {
+    let default: SocketAddr = "0.0.0.0:3030".parse().unwrap();
+
+    // Initialize the hasher.
+    if let Some(socket) = endpoint {
+        if *socket == default {
+            return Ok("0".to_string());
+        }
+
+        let hasher = snarkvm::console::algorithms::BHP256::<N>::setup("aleo.dev.block")?;
+        let endpoint_str = socket.to_string();
+        let bits = endpoint_str.to_bits_le();
+        let hash = hasher.hash(&bits)?.to_bytes_le()?;
+        let hash_str = hex::encode(hash);
+
+        return Ok(hash_str[..hash_str.len().min(8)].to_string());
+    }
+
+    Ok("0".to_string())
+}
+
+/// Returns the ledger dir for the given base path
+pub fn custom_ledger_dir(network: u16, keep_state: bool, end_point_tag: &str, base: PathBuf) -> PathBuf {
+    let mut path = base.clone();
+    path.push(format!(".{}-{network}-{end_point_tag}", if keep_state { LEDGER_STD_DIR } else { LEDGER_TMP_DIR }));
+    path
+}
+
+/// Returns default ledger dir path
+pub fn amareleo_ledger_dir(network: u16, keep_state: bool, end_point_tag: &str) -> PathBuf {
+    let path = match std::env::current_dir() {
+        Ok(current_dir) => current_dir,
+        _ => PathBuf::from(env!("CARGO_MANIFEST_DIR")),
+    };
+    custom_ledger_dir(network, keep_state, end_point_tag, path)
+}
+
+/// Wraps ledger dir in a StorageMode type
+pub fn amareleo_storage_mode(ledger_path: PathBuf) -> StorageMode {
+    StorageMode::Custom(ledger_path)
+}
+
+pub fn amareleo_log_file(network: u16, keep_state: bool, end_point_tag: &str) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!("{}-{network}-{end_point_tag}.log", if keep_state { LOG_STD_FILE } else { LOG_TMP_FILE }));
+    path
+}
+
+/// Returns the path where a proposal cache file may be stored.
+pub fn proposal_cache_path(storage_mode: &StorageMode) -> Result<PathBuf> {
+    // Obtain the path to the ledger.
+    let mut path = match &storage_mode {
+        StorageMode::Custom(path) => path.clone(),
+        _ => bail!("Failed: Custom StorageMode expected!"),
+    };
+
+    // Get the ledger folder name
+    let filename = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| anyhow!("Failed: Cannot extract ledger folder name"))?;
+
+    // Swap folder name with cache filename
+    let filename = if filename.contains(LEDGER_DIR_TAG) {
+        filename.replace(LEDGER_DIR_TAG, PROPOSAL_CACHE_TAG)
+    } else {
+        bail!("Failed: Unexpected ledger folder name!")
+    };
+
+    // Swap ledger folder name with cahce filename
+    path.pop();
+    path.push(filename);
+
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_proposal_cache_path_from_invalid_ledger() {
+        let invalid = PathBuf::from("~/invalid");
+        let store_mode = amareleo_storage_mode(invalid);
+
+        let res = proposal_cache_path(&store_mode);
+        assert!(res.is_err(), "Expected an error, but got Ok.");
+    }
+
+    #[test]
+    fn test_proposal_cache_path_from_invalid_store_mode() {
+        let store_mode = StorageMode::Development(0);
+        let res = proposal_cache_path(&store_mode);
+        assert!(res.is_err(), "Expected an error, but got Ok.");
+    }
+}

--- a/node/bft/src/helpers/mod.rs
+++ b/node/bft/src/helpers/mod.rs
@@ -22,6 +22,9 @@ pub use dag::*;
 pub mod partition;
 pub use partition::*;
 
+pub mod ledger_files;
+pub use ledger_files::*;
+
 pub mod proposal_cache;
 pub use proposal_cache::*;
 

--- a/node/bft/src/helpers/proposal_cache.rs
+++ b/node/bft/src/helpers/proposal_cache.rs
@@ -29,6 +29,8 @@ const LEDGER_STD_DIR: &str = "amareleo-ledger";
 const LEDGER_TMP_DIR: &str = "amareleo-tmp-ledger";
 const LEDGER_DIR_TAG: &str = "-ledger-";
 const PROPOSAL_CACHE_TAG: &str = "-proposal-cache-";
+const LOG_STD_FILE: &str = "amareleo-chain";
+const LOG_TMP_FILE: &str = "amareleo-chain-tmp";
 
 /// A string derived from the hash of the REST endpoint, giving us a unique filename per endpoint.
 pub fn endpoint_file_tag<N: Network>(endpoint: &Option<SocketAddr>) -> Result<String> {
@@ -71,6 +73,12 @@ pub fn amareleo_ledger_dir(network: u16, keep_state: bool, end_point_tag: &str) 
 /// Wraps ledger dir in a StorageMode type
 pub fn amareleo_storage_mode(ledger_path: PathBuf) -> StorageMode {
     StorageMode::Custom(ledger_path)
+}
+
+pub fn amareleo_log_file(network: u16, keep_state: bool, end_point_tag: &str) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!("{}-{network}-{end_point_tag}.log", if keep_state { LOG_STD_FILE } else { LOG_TMP_FILE }));
+    path
 }
 
 /// Returns the path where a proposal cache file may be stored.

--- a/node/bft/src/helpers/proposal_cache.rs
+++ b/node/bft/src/helpers/proposal_cache.rs
@@ -43,8 +43,8 @@ pub fn endpoint_file_tag<N: Network>(endpoint: &Option<SocketAddr>) -> Result<St
         let hasher = snarkvm::console::algorithms::BHP256::<N>::setup("aleo.dev.block")?;
         let endpoint_str = socket.to_string();
         let bits = endpoint_str.to_bits_le();
-        let hash = hasher.hash(&bits)?; //.to_bytes_le()?;
-        let hash_str = hash.to_string(); //hex::encode(hash);
+        let hash = hasher.hash(&bits)?.to_bytes_le()?;
+        let hash_str = hex::encode(hash);
 
         return Ok(hash_str[..hash_str.len().min(8)].to_string());
     }

--- a/node/bft/src/helpers/proposal_cache.rs
+++ b/node/bft/src/helpers/proposal_cache.rs
@@ -63,11 +63,8 @@ pub fn custom_ledger_dir(network: u16, keep_state: bool, base: PathBuf) -> PathB
     path
 }
 
-pub fn amareleo_storage_mode(network: u16, keep_state: bool, ledger_path: Option<PathBuf>) -> StorageMode {
-    match ledger_path {
-        Some(path) => StorageMode::Custom(path),
-        None => StorageMode::Custom(amareleo_ledger_dir(network, keep_state)),
-    }
+pub fn amareleo_storage_mode(ledger_path: PathBuf) -> StorageMode {
+    StorageMode::Custom(ledger_path)
 }
 
 /// A helper type for the cache of proposal and signed proposals.

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -138,10 +138,10 @@ impl<N: Network> Primary<N> {
     /// Load the proposal cache file and update the Primary state with the stored data.
     async fn load_proposal_cache(&self) -> Result<()> {
         // Fetch the signed proposals from the file system if it exists.
-        match ProposalCache::<N>::exists(self.keep_state, &self.storage_mode) {
+        match ProposalCache::<N>::exists(&self.storage_mode) {
             // If the proposal cache exists, then process the proposal cache.
             true => {
-                match ProposalCache::<N>::load(self.account.address(), self.keep_state, &self.storage_mode) {
+                match ProposalCache::<N>::load(self.account.address(), &self.storage_mode) {
                     Ok(proposal_cache) => {
                         // Extract the proposal and signed proposals.
                         let (latest_certificate_round, proposed_batch, signed_proposals, pending_certificates) =
@@ -1196,7 +1196,7 @@ impl<N: Network> Primary<N> {
                 ProposalCache::new(latest_round, proposal, signed_proposals, pending_certificates)
             };
 
-            if let Err(err) = proposal_cache.store(self.keep_state, &self.storage_mode) {
+            if let Err(err) = proposal_cache.store(&self.storage_mode) {
                 error!("Failed to store the current proposal cache: {err}");
             }
         }

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -125,7 +125,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
             snarkvm::console::network::TestnetV0::ID => "testnet",
             snarkvm::console::network::CanaryV0::ID => "canary",
             unknown_id => {
-                eprintln!("Unknown network ID ({unknown_id})");
+                error!("Unknown network ID ({unknown_id})");
                 return;
             }
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,21 @@
+use amareleo_chain::{BuildInfo, main_core};
+
+// Obtain information on the build.
+include!(concat!(env!("OUT_DIR"), "/built.rs"));
+
 fn main() -> anyhow::Result<()> {
     let pkg_name = env!("CARGO_PKG_NAME");
-    amareleo_chain::main_core(pkg_name, pkg_name)
+    let mut features = FEATURES_LOWERCASE_STR.to_owned();
+    features.retain(|c| c != ' ');
+
+    let build = BuildInfo {
+        bin: pkg_name,
+        version: PKG_VERSION,
+        repo: pkg_name,
+        branch: GIT_HEAD_REF.unwrap_or("unknown_branch"),
+        commit: GIT_COMMIT_HASH.unwrap_or("unknown_commit"),
+        features: &features,
+    };
+
+    main_core(&build)
 }


### PR DESCRIPTION
Running multiple amareleo-chain instances could easily cause conflicts as multiple instances would be assigned the same ledger folder. This wasn't an issue with snarkos since it was an unlikely scenario.

With amareleo-chain being much lighter, it is possible to run multiple instances mapping them to different ports. 

Such scenarios become more realistic once we deliver the programmatic API.