### PR TITLE
AmareleoApi is now a thread-safe singleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,7 @@ dependencies = [
  "amareleo-node-bft",
  "anyhow",
  "indexmap 2.7.0",
+ "parking_lot",
  "rand",
  "rand_chacha",
  "serial_test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,7 @@ dependencies = [
 name = "amareleo-chain-api"
 version = "2.1.0"
 dependencies = [
+ "aleo-std",
  "amareleo-chain-account",
  "amareleo-chain-resources",
  "amareleo-chain-tracing",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -33,6 +33,9 @@ default-features = false
 version = "1.28"
 features = ["rt", "rt-multi-thread"]
 
+[dependencies.parking_lot]
+version = "0.12"
+
 [dependencies.tracing]
 version = "0.1"
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -63,5 +63,8 @@ version = "=2.1.0"
 [dependencies.snarkvm]
 workspace = true
 
+[dependencies.aleo-std]
+workspace = true
+
 [dev-dependencies.serial_test]
 version = "3.2.0"

--- a/api/src/api/api_data.rs
+++ b/api/src/api/api_data.rs
@@ -1,0 +1,88 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{AmareleoApiState, AmareleoLog, ValidatorApi};
+
+use anyhow::{Result, bail};
+use std::{
+    net::SocketAddr,
+    path::PathBuf,
+    sync::{Arc, atomic::AtomicBool},
+};
+
+use amareleo_chain_tracing::{TracingHandler, initialize_tracing};
+use amareleo_node_bft::helpers::{amareleo_log_file, custom_ledger_dir, default_ledger_dir, endpoint_file_tag};
+
+// Private (only crate-wide visibility) lock-free AmareleoApi data storage
+pub(crate) struct AmareleoApiData {
+    pub state: AmareleoApiState,
+    pub prev_state: AmareleoApiState,
+    pub network_id: u16,
+    pub rest_ip: SocketAddr,
+    pub rest_rps: u32,
+    pub keep_state: bool,
+    pub ledger_base_path: Option<PathBuf>,
+    pub ledger_default_naming: bool,
+    pub log_mode: AmareleoLog,
+    pub tracing: Option<TracingHandler>,
+    pub verbosity: u8,
+    pub shutdown: Arc<AtomicBool>,
+    pub validator: ValidatorApi,
+}
+
+impl AmareleoApiData {
+    // Check if state matches the one required
+    pub fn is_state(&self, state: AmareleoApiState) -> bool {
+        self.state == state
+    }
+
+    /// Get log file path, based on current configuration.
+    pub fn get_log_file(&self) -> Result<PathBuf> {
+        if !self.log_mode.is_file() {
+            bail!("Logging to file is disabled!");
+        }
+
+        let log_option = self.log_mode.get_path();
+        let log_path = match &log_option {
+            Some(path) => path.clone(),
+            None => {
+                let end_point_tag = endpoint_file_tag(false, &self.rest_ip)?;
+                amareleo_log_file(self.network_id, self.keep_state, &end_point_tag)
+            }
+        };
+
+        Ok(log_path)
+    }
+
+    // Get ledger folder path, based on current configuration.
+    pub fn get_ledger_folder(&self) -> Result<PathBuf> {
+        let tag = endpoint_file_tag(self.ledger_default_naming, &self.rest_ip)?;
+        let ledger_path = match &self.ledger_base_path {
+            Some(base_path) => custom_ledger_dir(self.network_id, self.keep_state, &tag, base_path.clone()),
+            None => default_ledger_dir(self.network_id, self.keep_state, &tag),
+        };
+
+        Ok(ledger_path.to_path_buf())
+    }
+
+    // Initialze logging
+    pub fn trace_init(&mut self) -> Result<()> {
+        // Determine the effective TraceHandler
+        self.tracing = match &self.log_mode {
+            AmareleoLog::File(_) => Some(initialize_tracing(self.verbosity, self.get_log_file()?)?),
+            AmareleoLog::Custom(tracing) => Some(tracing.clone()),
+            AmareleoLog::None => None,
+        };
+
+        Ok(())
+    }
+}

--- a/api/src/api/api_helpers.rs
+++ b/api/src/api/api_helpers.rs
@@ -1,0 +1,295 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::PathBuf;
+
+use anyhow::{Result, bail, ensure};
+use indexmap::IndexMap;
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaChaRng;
+
+use snarkvm::{
+    console::{
+        account::{Address, PrivateKey},
+        algorithms::Hash,
+        network::{CanaryV0, MainnetV0, Network, TestnetV0},
+    },
+    ledger::{
+        block::Block,
+        committee::{Committee, MIN_VALIDATOR_STAKE},
+        store::{ConsensusStore, helpers::memory::ConsensusMemory},
+    },
+    prelude::{FromBytes, ToBits, ToBytes},
+    synthesizer::VM,
+    utilities::to_bytes_le,
+};
+
+use amareleo_chain_account::Account;
+use amareleo_chain_resources::{
+    BLOCK0_CANARY,
+    BLOCK0_CANARY_ID,
+    BLOCK0_MAINNET,
+    BLOCK0_MAINNET_ID,
+    BLOCK0_TESTNET,
+    BLOCK0_TESTNET_ID,
+};
+use amareleo_node_bft::{
+    DEVELOPMENT_MODE_NUM_GENESIS_COMMITTEE_MEMBERS,
+    DEVELOPMENT_MODE_RNG_SEED,
+    helpers::{amareleo_storage_mode, proposal_cache_path},
+};
+
+/// Get the fixed node account, loaded with public
+/// and private credits to pay for transaction fees.
+///
+/// # Returns
+///
+/// * `Result<Account<N>>` - the node primary account
+pub fn get_node_account<N: Network>() -> Result<Account<N>> {
+    Account::try_from({
+        // Initialize the (fixed) RNG.
+        let mut rng = ChaChaRng::seed_from_u64(DEVELOPMENT_MODE_RNG_SEED);
+        PrivateKey::<N>::new(&mut rng)?
+    })
+}
+
+/// Get the genesis block.
+///
+/// # Returns
+///
+/// * `Result<Block<N>>` - genesis block
+pub fn get_genesis<N: Network>() -> Result<Block<N>> {
+    // Initialize the (fixed) RNG.
+    let mut rng = ChaChaRng::seed_from_u64(DEVELOPMENT_MODE_RNG_SEED);
+
+    // Initialize the development private keys.
+    let development_private_keys = (0..DEVELOPMENT_MODE_NUM_GENESIS_COMMITTEE_MEMBERS)
+        .map(|_| PrivateKey::<N>::new(&mut rng))
+        .collect::<Result<Vec<_>>>()?;
+    // Initialize the development addresses.
+    let development_addresses =
+        development_private_keys.iter().map(Address::<N>::try_from).collect::<Result<Vec<_>>>()?;
+
+    let (committee, bonded_balances) = {
+        // Calculate the committee stake per member.
+        let stake_per_member =
+            N::STARTING_SUPPLY.saturating_div(2).saturating_div(DEVELOPMENT_MODE_NUM_GENESIS_COMMITTEE_MEMBERS as u64);
+        ensure!(stake_per_member >= MIN_VALIDATOR_STAKE, "Committee stake per member is too low");
+
+        // Construct the committee members and distribute stakes evenly among committee members.
+        let members = development_addresses
+            .iter()
+            .map(|address| (*address, (stake_per_member, true, rng.gen_range(0..100))))
+            .collect::<IndexMap<_, _>>();
+
+        // Construct the bonded balances.
+        // Note: The withdrawal address is set to the staker address.
+        let bonded_balances = members
+            .iter()
+            .map(|(address, (stake, _, _))| (*address, (*address, *address, *stake)))
+            .collect::<IndexMap<_, _>>();
+
+        // Construct the committee.
+        let committee = Committee::<N>::new(0u64, members)?;
+        (committee, bonded_balances)
+    };
+
+    // Ensure that the number of committee members is correct.
+    ensure!(
+        committee.members().len() == DEVELOPMENT_MODE_NUM_GENESIS_COMMITTEE_MEMBERS as usize,
+        "Number of committee members {} does not match the expected number of members {DEVELOPMENT_MODE_NUM_GENESIS_COMMITTEE_MEMBERS}",
+        committee.members().len()
+    );
+
+    // Calculate the public balance per validator.
+    let remaining_balance = N::STARTING_SUPPLY.saturating_sub(committee.total_stake());
+    let public_balance_per_validator =
+        remaining_balance.saturating_div(DEVELOPMENT_MODE_NUM_GENESIS_COMMITTEE_MEMBERS as u64);
+
+    // Construct the public balances with fairly equal distribution.
+    let mut public_balances = development_private_keys
+        .iter()
+        .map(|private_key| Ok((Address::try_from(private_key)?, public_balance_per_validator)))
+        .collect::<Result<IndexMap<_, _>>>()?;
+
+    // If there is some leftover balance, add it to the 0-th validator.
+    let leftover = remaining_balance
+        .saturating_sub(public_balance_per_validator * DEVELOPMENT_MODE_NUM_GENESIS_COMMITTEE_MEMBERS as u64);
+    if leftover > 0 {
+        let (_, balance) = public_balances.get_index_mut(0).unwrap();
+        *balance += leftover;
+    }
+
+    // Check if the sum of committee stakes and public balances equals the total starting supply.
+    let public_balances_sum: u64 = public_balances.values().copied().sum();
+    if committee.total_stake() + public_balances_sum != N::STARTING_SUPPLY {
+        bail!("Sum of committee stakes and public balances does not equal total starting supply.");
+    }
+
+    // Construct the genesis block.
+    load_or_compute_genesis::<N>(development_private_keys[0], committee, public_balances, bonded_balances, &mut rng)
+}
+
+// Check if network id is valid
+pub(crate) fn is_valid_network_id(network_id: u16) -> bool {
+    network_id == CanaryV0::ID || network_id == TestnetV0::ID || network_id == MainnetV0::ID
+}
+
+// Cleans the temporary ledger
+pub(crate) fn clean_tmp_ledger(ledger_path: PathBuf) -> Result<()> {
+    // Remove the current proposal cache file, if it exists.
+    let storage_mode = amareleo_storage_mode(ledger_path.clone());
+    let cache_path = proposal_cache_path(&storage_mode)?;
+    if cache_path.exists() {
+        if let Err(err) = std::fs::remove_file(&cache_path) {
+            bail!("Failed on removing proposal cache file at {}: {err}", cache_path.display());
+        }
+    }
+
+    // Remove ledger
+    if ledger_path.exists() {
+        if let Err(err) = std::fs::remove_dir_all(&ledger_path) {
+            bail!("Failed on removing ledger folder {}: {err}", ledger_path.display());
+        }
+    }
+
+    Ok(())
+}
+
+// Loads or computes the genesis block.
+pub(crate) fn load_or_compute_genesis<N: Network>(
+    genesis_private_key: PrivateKey<N>,
+    committee: Committee<N>,
+    public_balances: IndexMap<Address<N>, u64>,
+    bonded_balances: IndexMap<Address<N>, (Address<N>, Address<N>, u64)>,
+    rng: &mut ChaChaRng,
+) -> Result<Block<N>> {
+    // Construct the preimage.
+    let mut preimage = Vec::new();
+    let raw_block0: &[u8];
+    let raw_blockid: &str;
+
+    // Input the network ID.
+    preimage.extend(&N::ID.to_le_bytes());
+    // Input the genesis coinbase target.
+    preimage.extend(&to_bytes_le![N::GENESIS_COINBASE_TARGET]?);
+    // Input the genesis proof target.
+    preimage.extend(&to_bytes_le![N::GENESIS_PROOF_TARGET]?);
+
+    // Input the genesis private key, committee, and public balances.
+    preimage.extend(genesis_private_key.to_bytes_le()?);
+    preimage.extend(committee.to_bytes_le()?);
+    preimage.extend(&to_bytes_le![public_balances.iter().collect::<Vec<(_, _)>>()]?);
+    preimage.extend(&to_bytes_le![
+        bonded_balances
+            .iter()
+            .flat_map(|(staker, (validator, withdrawal, amount))| to_bytes_le![staker, validator, withdrawal, amount])
+            .collect::<Vec<_>>()
+    ]?);
+
+    // Input the parameters' metadata based on network
+    match N::ID {
+        MainnetV0::ID => {
+            preimage.extend(snarkvm::parameters::mainnet::BondValidatorVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::mainnet::BondPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::mainnet::UnbondPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::mainnet::ClaimUnbondPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::mainnet::SetValidatorStateVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::mainnet::TransferPrivateVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::mainnet::TransferPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::mainnet::TransferPrivateToPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::mainnet::TransferPublicToPrivateVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::mainnet::FeePrivateVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::mainnet::FeePublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::mainnet::InclusionVerifier::METADATA.as_bytes());
+            raw_block0 = BLOCK0_MAINNET;
+            raw_blockid = BLOCK0_MAINNET_ID;
+        }
+        TestnetV0::ID => {
+            preimage.extend(snarkvm::parameters::testnet::BondValidatorVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::testnet::BondPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::testnet::UnbondPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::testnet::ClaimUnbondPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::testnet::SetValidatorStateVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::testnet::TransferPrivateVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::testnet::TransferPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::testnet::TransferPrivateToPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::testnet::TransferPublicToPrivateVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::testnet::FeePrivateVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::testnet::FeePublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::testnet::InclusionVerifier::METADATA.as_bytes());
+            raw_block0 = BLOCK0_TESTNET;
+            raw_blockid = BLOCK0_TESTNET_ID;
+        }
+        CanaryV0::ID => {
+            preimage.extend(snarkvm::parameters::canary::BondValidatorVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::canary::BondPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::canary::UnbondPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::canary::ClaimUnbondPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::canary::SetValidatorStateVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::canary::TransferPrivateVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::canary::TransferPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::canary::TransferPrivateToPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::canary::TransferPublicToPrivateVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::canary::FeePrivateVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::canary::FeePublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::canary::InclusionVerifier::METADATA.as_bytes());
+            raw_block0 = BLOCK0_CANARY;
+            raw_blockid = BLOCK0_CANARY_ID;
+        }
+        _ => {
+            // Unrecognized Network ID
+            bail!("Unrecognized Network ID: {}", N::ID);
+        }
+    }
+
+    // Initialize the hasher.
+    let hasher = snarkvm::console::algorithms::BHP256::<N>::setup("aleo.dev.block")?;
+    // Compute the hash.
+    // NOTE: this is a fast-to-compute but *IMPERFECT* identifier for the genesis block;
+    //       to know the actual genesis block hash, you need to compute the block itself.
+    let hash = hasher.hash(&preimage.to_bits_le())?.to_string();
+    if hash == raw_blockid {
+        let block = Block::from_bytes_le(raw_block0)?;
+        return Ok(block);
+    }
+
+    // A closure to load the block.
+    let load_block = |file_path| -> Result<Block<N>> {
+        // Attempts to load the genesis block file locally.
+        let buffer = std::fs::read(file_path)?;
+        // Return the genesis block.
+        Block::from_bytes_le(&buffer)
+    };
+
+    // Construct the file path.
+    let file_path = std::env::temp_dir().join(hash);
+
+    // Check if the genesis block exists.
+    if file_path.exists() {
+        // If the block loads successfully, return it.
+        if let Ok(block) = load_block(&file_path) {
+            return Ok(block);
+        }
+    }
+
+    /* Otherwise, compute the genesis block and store it. */
+
+    // Initialize a new VM.
+    let vm = VM::from(ConsensusStore::<N, ConsensusMemory<N>>::open(0u16)?)?;
+    // Initialize the genesis block.
+    let block = vm.genesis_quorum(&genesis_private_key, committee, public_balances, bonded_balances, rng)?;
+    // Write the genesis block to the file.
+    std::fs::write(&file_path, block.to_bytes_le()?)?;
+    // Return the genesis block.
+    Ok(block)
+}

--- a/api/src/api/api_logs.rs
+++ b/api/src/api/api_logs.rs
@@ -17,14 +17,15 @@ use amareleo_chain_tracing::TracingHandler;
 /// Amareleo logging selection
 #[derive(Clone)]
 pub enum AmareleoLog {
-    /// Log to file
-    /// If Some, the specified path is used.
-    /// If None, the default log file path is used.
+    /// Log to file.
+    ///     - If Some, the specified path is used.
+    ///     - If None, the default log file path is used.
     File(Option<PathBuf>),
 
-    /// Custom log handler
-    /// Overrides the default log handler with your own
-    /// tracing subscribers.
+    /// Custom log handler.
+    ///
+    /// Overrides the default log handler by providing a
+    /// `TracingHandler` configured with tracing subscribers.
     Custom(TracingHandler),
 
     /// Disable logging
@@ -33,8 +34,11 @@ pub enum AmareleoLog {
 
 impl AmareleoLog {
     /// Get configured log file path
-    /// Returns Some when a custom log file path is configured.
-    /// Returns None when using the default path and when file logging is disabled.
+    ///
+    /// # Returns
+    ///
+    /// `Option<PathBuf>` - `Some(PathBuf)` when a custom log file path is configured.
+    /// `None` when using the default path and when file logging is disabled.
     pub fn get_path(&self) -> Option<PathBuf> {
         match self {
             Self::File(path) => path.clone(),
@@ -43,16 +47,28 @@ impl AmareleoLog {
     }
 
     /// Check if file logging is enabled
+    ///
+    /// # Returns
+    ///
+    /// Returns `true` when file logging is enabled, `false` otherwise.
     pub fn is_file(&self) -> bool {
         matches!(self, Self::File(_))
     }
 
     /// Check if custom logging is enabled
+    ///
+    /// # Returns
+    ///
+    /// Returns `true` when custom logging is enabled, `false` otherwise.
     pub fn is_custom(&self) -> bool {
         matches!(self, Self::Custom(_))
     }
 
     /// Check if logging is disabled altogether
+    ///
+    /// # Returns
+    ///
+    /// Returns `true` when logging is disabled, `false` otherwise.
     pub fn is_none(&self) -> bool {
         matches!(self, Self::None)
     }

--- a/api/src/api/api_node.rs
+++ b/api/src/api/api_node.rs
@@ -9,95 +9,83 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use crate::{AmareleoLog, ValidatorApi};
 
-use std::{
-    net::SocketAddr,
-    path::PathBuf,
-    sync::{Arc, atomic::AtomicBool},
+use crate::{
+    AmareleoApiData,
+    AmareleoApiState,
+    AmareleoLog,
+    ValidatorApi,
+    ValidatorNewData,
+    clean_tmp_ledger,
+    is_valid_network_id,
 };
 
-use anyhow::{Result, bail, ensure};
-use indexmap::IndexMap;
-use rand::{Rng, SeedableRng};
-use rand_chacha::ChaChaRng;
+use std::{net::SocketAddr, path::PathBuf, sync::OnceLock};
 
-use snarkvm::{
-    console::{
-        account::{Address, PrivateKey},
-        algorithms::Hash,
-        network::{CanaryV0, MainnetV0, Network, TestnetV0},
-    },
-    ledger::{
-        block::Block,
-        committee::{Committee, MIN_VALIDATOR_STAKE},
-        store::{ConsensusStore, helpers::memory::ConsensusMemory},
-    },
-    prelude::{FromBytes, ToBits, ToBytes},
-    synthesizer::VM,
-    utilities::to_bytes_le,
-};
+use anyhow::{Result, bail};
+use parking_lot::Mutex;
+use snarkvm::console::network::{Network, TestnetV0};
 
-use amareleo_chain_account::Account;
-use amareleo_chain_resources::{
-    BLOCK0_CANARY,
-    BLOCK0_CANARY_ID,
-    BLOCK0_MAINNET,
-    BLOCK0_MAINNET_ID,
-    BLOCK0_TESTNET,
-    BLOCK0_TESTNET_ID,
-};
-use amareleo_chain_tracing::{TracingHandler, initialize_tracing};
-use amareleo_node_bft::{
-    DEVELOPMENT_MODE_NUM_GENESIS_COMMITTEE_MEMBERS,
-    DEVELOPMENT_MODE_RNG_SEED,
-    helpers::{
-        amareleo_log_file,
-        amareleo_storage_mode,
-        custom_ledger_dir,
-        default_ledger_dir,
-        endpoint_file_tag,
-        proposal_cache_path,
-    },
-};
+use amareleo_chain_tracing::TracingHandler;
+use amareleo_node_bft::helpers::amareleo_storage_mode;
+
+// ===================================================================
+// AmareleoApi is a simple thread-safe singleton.
+// There should be little scope for accessing this object
+// from concurrent threads. Thus we adopt a simple non-rentrant
+// Mutex that locks all data both on reading and writing.
+//
+// The non-rentrant Mutex, requires that functions acquiring
+// the Mutex lock do not call other functions that would also lock
+// the same Mutex. That would lead to a deadlock.
+//
+// The general rule is to only let public functions lock the Mutex,
+// such that private functions can be safely shared. However this
+// rule is not strictly followed. See the start(), end() and try_*()
+// functions for example.
+//
+// The AmareleoApiData struct is a lock-free private space most
+// appropriate for reusable code. This struct is private and has no
+// access to the Mutex.
+//
+// ===================================================================
 
 /// Amareleo node object, for creating and managing a node instance
 pub struct AmareleoApi {
-    network_id: u16,
-    rest_ip: SocketAddr,
-    rest_rps: u32,
-    keep_state: bool,
-    ledger_base_path: Option<PathBuf>,
-    ledger_default_naming: bool,
-    log_mode: AmareleoLog,
-    log_trace: Option<TracingHandler>,
-    verbosity: u8,
-    shutdown: Arc<AtomicBool>,
-    validator: ValidatorApi,
+    data: Mutex<AmareleoApiData>,
 }
 
-impl Default for AmareleoApi {
-    /// Create a node with default configuration.
-    /// - Testnet node
+// Global storage for the singleton instance
+static INSTANCE: OnceLock<AmareleoApi> = OnceLock::new();
+
+impl AmareleoApi {
+    /// Create or return the singleton instance of AmareleoApi.
+    ///
+    /// When called for the first time the node is initialized with:
+    /// - Testnet network
     /// - Bound to localhost port 3030
     /// - REST limited to 10 requests per second
-    /// - No ledger state retenttion
+    /// - No ledger state retenttion across runs
     /// - Unique ledger folder naming
     /// - Logging disabled
-    fn default() -> Self {
-        Self {
-            network_id: TestnetV0::ID,
-            rest_ip: "0.0.0.0:3030".parse().unwrap(),
-            rest_rps: 10u32,
-            keep_state: false,
-            ledger_base_path: None,
-            ledger_default_naming: false,
-            log_mode: AmareleoLog::None,
-            log_trace: None,
-            verbosity: 1u8,
-            shutdown: Default::default(),
-            validator: ValidatorApi::None,
-        }
+    pub fn new() -> &'static Self {
+        INSTANCE.get_or_init(|| Self {
+            data: Mutex::new(AmareleoApiData {
+                state: AmareleoApiState::Init,
+                prev_state: AmareleoApiState::Init,
+                network_id: TestnetV0::ID,
+                rest_ip: "0.0.0.0:3030".parse().unwrap(),
+                rest_rps: 10u32,
+                keep_state: false,
+                ledger_base_path: None,
+                ledger_default_naming: false,
+                log_mode: AmareleoLog::None,
+                tracing: None,
+                verbosity: 1u8,
+                shutdown: Default::default(),
+                validator: ValidatorApi::None,
+            }),
+        })
     }
 }
 
@@ -108,206 +96,206 @@ impl AmareleoApi {
     /// - TestnetV0::ID
     /// - MainnetV0::ID
     ///
-    /// Note: This method should be called before starting the node.<br>
-    /// If the node is already started, this method will have no effect.<br>
-    /// If the network ID is invalid, the value will be ignored.
-    ///
     /// # Parameters
     ///
-    /// * network_id: `u16` - network ID to use
-    pub fn cfg_network_id(&mut self, network_id: u16) -> &mut Self {
-        if !self.is_started()
-            && (network_id == CanaryV0::ID || network_id == TestnetV0::ID || network_id == MainnetV0::ID)
-        {
-            self.network_id = network_id;
+    /// * network_id: `u16` - network ID to use.
+    ///
+    /// # Returns
+    ///
+    /// * `Err` if node is NOT in the `Init` state.
+    /// * `Err` if network_id is invalid.
+    pub fn cfg_network(&self, network_id: u16) -> Result<()> {
+        let mut data = self.data.lock();
+
+        if !data.is_state(AmareleoApiState::Init) {
+            bail!("Invalid node state {:?}", data.state);
         }
 
+        if !is_valid_network_id(network_id) {
+            bail!("Invalid network id {network_id}");
+        }
+        data.network_id = network_id;
+        Ok(())
+    }
+
+    /// Same as `cfg_network` but fails silently.
+    ///
+    /// # Returns
+    ///
+    /// `&Self` allowing for chaining `try_cfg_*()` calls
+    pub fn try_cfg_network(&self, network_id: u16) -> &Self {
+        let _ = self.cfg_network(network_id);
         self
     }
 
     /// Configure REST server IP, port, and requests per second limit.
     ///
-    /// Note: This method should be called before starting the node.<br>
-    /// If the node is already started, this method will have no effect.<br>
-    ///
     /// # Parameters
     ///
     /// * ip_port: `SocketAddr` - IP and port to listen to
     /// * rps: `u32` - requests per second limit
-    pub fn cfg_rest(&mut self, ip_port: SocketAddr, rps: u32) -> &mut Self {
-        if !self.is_started() {
-            self.rest_ip = ip_port;
-            self.rest_rps = rps;
-        }
+    ///
+    /// # Returns
+    ///
+    /// * `Err` if node is NOT in the `Init` state.
+    pub fn cfg_rest(&self, ip_port: SocketAddr, rps: u32) -> Result<()> {
+        let mut data = self.data.lock();
 
+        if !data.is_state(AmareleoApiState::Init) {
+            bail!("Invalid node state {:?}", data.state);
+        }
+        data.rest_ip = ip_port;
+        data.rest_rps = rps;
+        Ok(())
+    }
+
+    /// Same as `cfg_rest` but fails silently.
+    ///
+    /// # Returns
+    ///
+    /// `&Self` allowing for chaining `try_cfg_*()` calls
+    pub fn try_cfg_rest(&self, ip_port: SocketAddr, rps: u32) -> &Self {
+        let _ = self.cfg_rest(ip_port, rps);
         self
     }
 
     /// Configure ledger storage properties.
     ///
-    /// Note: This method should be called before starting the node.<br>
-    /// If the node is already started, this method will have no effect.<br>
-    ///
     /// # Parameters
     ///
     /// * keep_state: `bool` - keep ledger state between restarts
     /// * base_path: `Option<PathBuf>` - custom ledger folder path
-    /// * default_naming: `bool` - use default ledger folder naming, instead of deriving unique names from the rest IP:port configuration.
-    pub fn cfg_ledger(&mut self, keep_state: bool, base_path: Option<PathBuf>, default_naming: bool) -> &mut Self {
-        if !self.is_started() {
-            self.keep_state = keep_state;
-            self.ledger_base_path = base_path;
-            self.ledger_default_naming = default_naming;
-        }
+    /// * default_naming: `bool` - if `true` use fixed ledger folder naming, instead of deriving a unique name from the rest IP:port configuration.
+    ///
+    /// # Returns
+    ///
+    /// * `Err` if node is NOT in the `Init` state.
+    pub fn cfg_ledger(&self, keep_state: bool, base_path: Option<PathBuf>, default_naming: bool) -> Result<()> {
+        let mut data = self.data.lock();
 
+        if !data.is_state(AmareleoApiState::Init) {
+            bail!("Invalid node state {:?}", data.state);
+        }
+        data.keep_state = keep_state;
+        data.ledger_base_path = base_path;
+        data.ledger_default_naming = default_naming;
+        Ok(())
+    }
+
+    /// Same as `cfg_ledger` but fails silently.
+    ///
+    /// # Returns
+    ///
+    /// `&Self` allowing for chaining `try_cfg_*()` calls
+    pub fn try_cfg_ledger(&self, keep_state: bool, base_path: Option<PathBuf>, default_naming: bool) -> &Self {
+        let _ = self.cfg_ledger(keep_state, base_path, default_naming);
         self
     }
 
     /// Configure file logging path and verbosity level.
     ///
-    /// Note: This method should be called before starting the node.<br>
-    /// If the node is already started, this method will have no effect.<br>
-    ///
     /// # Parameters
     ///
     /// * log_file: `Option<PathBuf>` - custom log file path, or None for default path
     /// * verbosity: `u8` - log verbosity level between 0 and 4, where 0 is the least verbose
-    pub fn cfg_file_log(&mut self, log_file: Option<PathBuf>, verbosity: u8) -> &mut Self {
-        if !self.is_started() {
-            self.log_mode = AmareleoLog::File(log_file);
-            self.verbosity = verbosity;
-        }
+    ///
+    /// # Returns
+    ///
+    /// * `Err` if node is NOT in the `Init` or `Stopped` state.
+    pub fn cfg_file_log(&self, log_file: Option<PathBuf>, verbosity: u8) -> Result<()> {
+        let mut data = self.data.lock();
 
+        if !data.is_state(AmareleoApiState::Init) && !data.is_state(AmareleoApiState::Stopped) {
+            bail!("Invalid node state {:?}", data.state);
+        }
+        data.log_mode = AmareleoLog::File(log_file);
+        data.verbosity = verbosity;
+        Ok(())
+    }
+
+    /// Same as `cfg_file_log` but fails silently.
+    ///
+    /// # Returns
+    ///
+    /// `&Self` allowing for chaining `try_cfg_*()` calls
+    pub fn try_cfg_file_log(&self, log_file: Option<PathBuf>, verbosity: u8) -> &Self {
+        let _ = self.cfg_file_log(log_file, verbosity);
         self
     }
 
     /// Configure custom tracing subscribers.
     ///
-    /// Note: This method should be called before starting the node.<br>
-    /// If the node is already started, this method will have no effect.<br>
-    ///
     /// # Parameters
     ///
     /// * tracing: `TracingHandler` - custom tracing subscriber
-    pub fn cfg_custom_log(&mut self, tracing: TracingHandler) -> &mut Self {
-        if !self.is_started() {
-            self.log_mode = AmareleoLog::Custom(tracing);
-        }
+    ///
+    /// # Returns
+    ///
+    /// * `Err` if node is NOT in the `Init` or `Stopped` state.
+    pub fn cfg_custom_log(&self, tracing: TracingHandler) -> Result<()> {
+        let mut data = self.data.lock();
 
+        if !data.is_state(AmareleoApiState::Init) && !data.is_state(AmareleoApiState::Stopped) {
+            bail!("Invalid node state {:?}", data.state);
+        }
+        data.log_mode = AmareleoLog::Custom(tracing);
+        Ok(())
+    }
+
+    /// Same as `cfg_custom_log` but fails silently.
+    ///
+    /// # Returns
+    ///
+    /// `&Self` allowing for chaining `try_cfg_*()` calls
+    pub fn try_cfg_custom_log(&self, tracing: TracingHandler) -> &Self {
+        let _ = self.cfg_custom_log(tracing);
         self
     }
 
     /// Disable logging.
     ///
-    /// Note: This method should be called before starting the node.<br>
-    /// If the node is already started, this method will have no effect.<br>
-    pub fn cfg_no_log(&mut self) -> &mut Self {
-        if !self.is_started() {
-            self.log_mode = AmareleoLog::None;
-        }
+    /// # Returns
+    ///
+    /// * `Err` if node is NOT in the `Init` or `Stopped` state.
+    pub fn cfg_no_log(&self) -> Result<()> {
+        let mut data = self.data.lock();
 
+        if !data.is_state(AmareleoApiState::Init) && !data.is_state(AmareleoApiState::Stopped) {
+            bail!("Invalid node state {:?}", data.state);
+        }
+        data.log_mode = AmareleoLog::None;
+        Ok(())
+    }
+
+    /// Same as `cfg_no_log` but fails silently.
+    ///
+    /// # Returns
+    ///
+    /// `&Self` allowing for chaining `try_cfg_*()` calls
+    pub fn try_cfg_no_log(&self) -> &Self {
+        let _ = self.cfg_no_log();
         self
     }
 }
 
 // AmareleoApi public getters
 impl AmareleoApi {
-    /// Get the fixed node account, loaded with public
-    /// and private credits to pay for transaction fees.
+    /// Get the node object state
     ///
     /// # Returns
     ///
-    /// * `Result<Account<N>>` - the node primary account
-    pub fn get_node_account<N: Network>() -> Result<Account<N>> {
-        Account::try_from({
-            // Initialize the (fixed) RNG.
-            let mut rng = ChaChaRng::seed_from_u64(DEVELOPMENT_MODE_RNG_SEED);
-            PrivateKey::<N>::new(&mut rng)?
-        })
+    /// * `AmareleoApiState` - one of the enum state values.
+    pub fn get_state(&self) -> AmareleoApiState {
+        self.data.lock().state
     }
 
-    /// Get the genesis block.
+    /// Check if the node is started
     ///
     /// # Returns
     ///
-    /// * `Result<Block<N>>` - genesis block
-    pub fn get_genesis<N: Network>() -> Result<Block<N>> {
-        // Initialize the (fixed) RNG.
-        let mut rng = ChaChaRng::seed_from_u64(DEVELOPMENT_MODE_RNG_SEED);
-
-        // Initialize the development private keys.
-        let development_private_keys = (0..DEVELOPMENT_MODE_NUM_GENESIS_COMMITTEE_MEMBERS)
-            .map(|_| PrivateKey::<N>::new(&mut rng))
-            .collect::<Result<Vec<_>>>()?;
-        // Initialize the development addresses.
-        let development_addresses =
-            development_private_keys.iter().map(Address::<N>::try_from).collect::<Result<Vec<_>>>()?;
-
-        let (committee, bonded_balances) = {
-            // Calculate the committee stake per member.
-            let stake_per_member = N::STARTING_SUPPLY
-                .saturating_div(2)
-                .saturating_div(DEVELOPMENT_MODE_NUM_GENESIS_COMMITTEE_MEMBERS as u64);
-            ensure!(stake_per_member >= MIN_VALIDATOR_STAKE, "Committee stake per member is too low");
-
-            // Construct the committee members and distribute stakes evenly among committee members.
-            let members = development_addresses
-                .iter()
-                .map(|address| (*address, (stake_per_member, true, rng.gen_range(0..100))))
-                .collect::<IndexMap<_, _>>();
-
-            // Construct the bonded balances.
-            // Note: The withdrawal address is set to the staker address.
-            let bonded_balances = members
-                .iter()
-                .map(|(address, (stake, _, _))| (*address, (*address, *address, *stake)))
-                .collect::<IndexMap<_, _>>();
-
-            // Construct the committee.
-            let committee = Committee::<N>::new(0u64, members)?;
-            (committee, bonded_balances)
-        };
-
-        // Ensure that the number of committee members is correct.
-        ensure!(
-            committee.members().len() == DEVELOPMENT_MODE_NUM_GENESIS_COMMITTEE_MEMBERS as usize,
-            "Number of committee members {} does not match the expected number of members {DEVELOPMENT_MODE_NUM_GENESIS_COMMITTEE_MEMBERS}",
-            committee.members().len()
-        );
-
-        // Calculate the public balance per validator.
-        let remaining_balance = N::STARTING_SUPPLY.saturating_sub(committee.total_stake());
-        let public_balance_per_validator =
-            remaining_balance.saturating_div(DEVELOPMENT_MODE_NUM_GENESIS_COMMITTEE_MEMBERS as u64);
-
-        // Construct the public balances with fairly equal distribution.
-        let mut public_balances = development_private_keys
-            .iter()
-            .map(|private_key| Ok((Address::try_from(private_key)?, public_balance_per_validator)))
-            .collect::<Result<IndexMap<_, _>>>()?;
-
-        // If there is some leftover balance, add it to the 0-th validator.
-        let leftover = remaining_balance
-            .saturating_sub(public_balance_per_validator * DEVELOPMENT_MODE_NUM_GENESIS_COMMITTEE_MEMBERS as u64);
-        if leftover > 0 {
-            let (_, balance) = public_balances.get_index_mut(0).unwrap();
-            *balance += leftover;
-        }
-
-        // Check if the sum of committee stakes and public balances equals the total starting supply.
-        let public_balances_sum: u64 = public_balances.values().copied().sum();
-        if committee.total_stake() + public_balances_sum != N::STARTING_SUPPLY {
-            bail!("Sum of committee stakes and public balances does not equal total starting supply.");
-        }
-
-        // Construct the genesis block.
-        Self::load_or_compute_genesis::<N>(
-            development_private_keys[0],
-            committee,
-            public_balances,
-            bonded_balances,
-            &mut rng,
-        )
+    /// * `bool` - `true` if the node is running, `false` otherwise
+    pub fn is_started(&self) -> bool {
+        self.data.lock().is_state(AmareleoApiState::Started)
     }
 
     /// Get log file path, based on current configuration.
@@ -317,263 +305,133 @@ impl AmareleoApi {
     /// Properties that effect the log file path include:<br>
     /// - REST endpont
     /// - network ID
-    /// - ledger state retantion flag
+    /// - ledger state retention flag
     ///
     /// # Returns
     ///
     /// * `Result<PathBuf>` - log file path
     pub fn get_log_file(&self) -> Result<PathBuf> {
-        if !self.log_mode.is_file() {
-            bail!("Logging to file is disabled!");
-        }
-
-        let log_option = self.log_mode.get_path();
-        let log_path = match &log_option {
-            Some(path) => path.clone(),
-            None => {
-                let end_point_tag = endpoint_file_tag(false, &self.rest_ip)?;
-                amareleo_log_file(self.network_id, self.keep_state, &end_point_tag)
-            }
-        };
-
-        Ok(log_path)
+        self.data.lock().get_log_file()
     }
 
     /// Get ledger folder path, based on the current configuration.
     ///
     /// Note: Changes in configuration may cause the ledger path to change.<br>
     /// Properties that effect the ledger path include:<br>
-    /// - REST endpont
+    /// - REST endpont (if default naming is disabled)
     /// - network ID
-    /// - ledger state retantion flag
+    /// - ledger state retention flag
     ///
     /// # Returns
     ///
     /// * `Result<PathBuf>` - ledger file path
     pub fn get_ledger_folder(&self) -> Result<PathBuf> {
-        let tag = endpoint_file_tag(self.ledger_default_naming, &self.rest_ip)?;
-        let ledger_path = match &self.ledger_base_path {
-            Some(base_path) => custom_ledger_dir(self.network_id, self.keep_state, &tag, base_path.clone()),
-            None => default_ledger_dir(self.network_id, self.keep_state, &tag),
-        };
-
-        Ok(ledger_path.to_path_buf())
-    }
-
-    /// Check if the node is started
-    ///
-    /// # Returns
-    ///
-    /// * `bool` - true if the node is running, false otherwise
-    pub fn is_started(&self) -> bool {
-        self.validator.is_started()
+        self.data.lock().get_ledger_folder()
     }
 }
 
-// AmareleoApi operations for public consumption
+// AmareleoApi node start operation
 impl AmareleoApi {
-    /// Start a node instance
-    pub async fn start(&mut self) -> Result<()> {
-        if self.is_started() {
-            bail!("Node already started");
+    /// Start node instance
+    ///
+    /// Method should be called when node is in the `Init` or `Stopped` state.<br>
+    /// If the node is in any other state, the method fails.
+    pub async fn start(&self) -> Result<()> {
+        // The state rules are enforced within start_prep/start_complete
+        // Sandwiching validator::new between them, secures against
+        // concurrency.
+        let validator_data = self.start_prep()?;
+        let res = ValidatorApi::new(validator_data).await;
+
+        match res {
+            Ok(vapi) => {
+                self.start_complete(vapi);
+            }
+            Err(error) => {
+                self.start_revert();
+                return Err(error);
+            }
+        };
+
+        Ok(())
+    }
+
+    fn start_prep(&self) -> Result<ValidatorNewData> {
+        let mut data = self.data.lock();
+
+        if !data.is_state(AmareleoApiState::Init) && !data.is_state(AmareleoApiState::Stopped) {
+            bail!("Invalid node state {:?}", data.state);
         }
 
-        let ledger_path = self.get_ledger_folder()?;
+        let ledger_path = data.get_ledger_folder()?;
         let storage_mode = amareleo_storage_mode(ledger_path.clone());
-        if !self.keep_state {
+
+        data.trace_init()?;
+
+        if !data.keep_state {
             // Clean the temporary ledger.
-            Self::clean_tmp_ledger(ledger_path)?;
+            clean_tmp_ledger(ledger_path)?;
         }
+        data.prev_state = data.state;
+        data.state = AmareleoApiState::StartPending;
 
-        self.trace_init()?;
-
-        // Initialize the validator.
-        self.validator = ValidatorApi::new(
-            self.network_id,
-            self.rest_ip,
-            self.rest_rps,
-            self.keep_state,
-            storage_mode,
-            self.log_trace.clone(),
-            self.shutdown.clone(),
-        )
-        .await?;
-
-        Ok(())
+        Ok(ValidatorNewData {
+            network_id: data.network_id,
+            rest_ip: data.rest_ip,
+            rest_rps: data.rest_rps,
+            keep_state: data.keep_state,
+            storage_mode: storage_mode.clone(),
+            tracing: data.tracing.clone(),
+            shutdown: data.shutdown.clone(),
+        })
     }
 
-    /// Stop the node instance
-    pub async fn end(&mut self) {
-        if self.is_started() {
-            self.validator.shut_down().await;
-            self.validator = ValidatorApi::None;
-        }
+    fn start_complete(&self, validator: ValidatorApi) {
+        let mut data = self.data.lock();
+        data.validator = validator;
+        data.prev_state = data.state;
+        data.state = AmareleoApiState::Started;
+    }
+
+    fn start_revert(&self) {
+        let mut data = self.data.lock();
+        data.state = data.prev_state;
     }
 }
 
-// AmareleoApi private helpers
+// AmareleoApi node stop operation
 impl AmareleoApi {
-    // Initialze logging
-    fn trace_init(&mut self) -> Result<()> {
-        // Determine the effective TraceHandler
-        self.log_trace = match &self.log_mode {
-            AmareleoLog::File(_) => Some(initialize_tracing(self.verbosity, self.get_log_file()?)?),
-            AmareleoLog::Custom(tracing) => Some(tracing.clone()),
-            AmareleoLog::None => None,
-        };
-
+    /// Stop node instance
+    ///
+    /// Method should be called when node is in the `Started` state.<br>
+    /// If the node is in any other state, the method fails.
+    pub async fn end(&self) -> Result<()> {
+        // The state rules are enforced within end_prep/end_complete
+        // Sandwiching validator::shut_down between them, secures
+        // against concurrency.
+        let validator_ = self.end_prep()?;
+        validator_.shut_down().await;
+        self.end_complete();
         Ok(())
     }
 
-    // Cleans the temporary ledger
-    fn clean_tmp_ledger(ledger_path: PathBuf) -> Result<()> {
-        // Remove the current proposal cache file, if it exists.
-        let storage_mode = amareleo_storage_mode(ledger_path.clone());
-        let cache_path = proposal_cache_path(&storage_mode)?;
-        if cache_path.exists() {
-            if let Err(err) = std::fs::remove_file(&cache_path) {
-                bail!("Failed on removing proposal cache file at {}: {err}", cache_path.display());
-            }
-        }
+    fn end_prep(&self) -> Result<ValidatorApi> {
+        let mut data = self.data.lock();
 
-        // Remove ledger
-        if ledger_path.exists() {
-            if let Err(err) = std::fs::remove_dir_all(&ledger_path) {
-                bail!("Failed on removing ledger folder {}: {err}", ledger_path.display());
-            }
+        if !data.is_state(AmareleoApiState::Started) {
+            bail!("Invalid node state {:?}", data.state);
         }
+        data.prev_state = data.state;
+        data.state = AmareleoApiState::StopPending;
 
-        Ok(())
+        Ok(data.validator.clone())
     }
 
-    // Loads or computes the genesis block.
-    fn load_or_compute_genesis<N: Network>(
-        genesis_private_key: PrivateKey<N>,
-        committee: Committee<N>,
-        public_balances: IndexMap<Address<N>, u64>,
-        bonded_balances: IndexMap<Address<N>, (Address<N>, Address<N>, u64)>,
-        rng: &mut ChaChaRng,
-    ) -> Result<Block<N>> {
-        // Construct the preimage.
-        let mut preimage = Vec::new();
-        let raw_block0: &[u8];
-        let raw_blockid: &str;
+    fn end_complete(&self) {
+        let mut data = self.data.lock();
 
-        // Input the network ID.
-        preimage.extend(&N::ID.to_le_bytes());
-        // Input the genesis coinbase target.
-        preimage.extend(&to_bytes_le![N::GENESIS_COINBASE_TARGET]?);
-        // Input the genesis proof target.
-        preimage.extend(&to_bytes_le![N::GENESIS_PROOF_TARGET]?);
-
-        // Input the genesis private key, committee, and public balances.
-        preimage.extend(genesis_private_key.to_bytes_le()?);
-        preimage.extend(committee.to_bytes_le()?);
-        preimage.extend(&to_bytes_le![public_balances.iter().collect::<Vec<(_, _)>>()]?);
-        preimage.extend(&to_bytes_le![
-            bonded_balances
-                .iter()
-                .flat_map(|(staker, (validator, withdrawal, amount))| to_bytes_le![
-                    staker, validator, withdrawal, amount
-                ])
-                .collect::<Vec<_>>()
-        ]?);
-
-        // Input the parameters' metadata based on network
-        match N::ID {
-            MainnetV0::ID => {
-                preimage.extend(snarkvm::parameters::mainnet::BondValidatorVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::mainnet::BondPublicVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::mainnet::UnbondPublicVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::mainnet::ClaimUnbondPublicVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::mainnet::SetValidatorStateVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::mainnet::TransferPrivateVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::mainnet::TransferPublicVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::mainnet::TransferPrivateToPublicVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::mainnet::TransferPublicToPrivateVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::mainnet::FeePrivateVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::mainnet::FeePublicVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::mainnet::InclusionVerifier::METADATA.as_bytes());
-                raw_block0 = BLOCK0_MAINNET;
-                raw_blockid = BLOCK0_MAINNET_ID;
-            }
-            TestnetV0::ID => {
-                preimage.extend(snarkvm::parameters::testnet::BondValidatorVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::testnet::BondPublicVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::testnet::UnbondPublicVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::testnet::ClaimUnbondPublicVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::testnet::SetValidatorStateVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::testnet::TransferPrivateVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::testnet::TransferPublicVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::testnet::TransferPrivateToPublicVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::testnet::TransferPublicToPrivateVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::testnet::FeePrivateVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::testnet::FeePublicVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::testnet::InclusionVerifier::METADATA.as_bytes());
-                raw_block0 = BLOCK0_TESTNET;
-                raw_blockid = BLOCK0_TESTNET_ID;
-            }
-            CanaryV0::ID => {
-                preimage.extend(snarkvm::parameters::canary::BondValidatorVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::canary::BondPublicVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::canary::UnbondPublicVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::canary::ClaimUnbondPublicVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::canary::SetValidatorStateVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::canary::TransferPrivateVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::canary::TransferPublicVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::canary::TransferPrivateToPublicVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::canary::TransferPublicToPrivateVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::canary::FeePrivateVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::canary::FeePublicVerifier::METADATA.as_bytes());
-                preimage.extend(snarkvm::parameters::canary::InclusionVerifier::METADATA.as_bytes());
-                raw_block0 = BLOCK0_CANARY;
-                raw_blockid = BLOCK0_CANARY_ID;
-            }
-            _ => {
-                // Unrecognized Network ID
-                bail!("Unrecognized Network ID: {}", N::ID);
-            }
-        }
-
-        // Initialize the hasher.
-        let hasher = snarkvm::console::algorithms::BHP256::<N>::setup("aleo.dev.block")?;
-        // Compute the hash.
-        // NOTE: this is a fast-to-compute but *IMPERFECT* identifier for the genesis block;
-        //       to know the actual genesis block hash, you need to compute the block itself.
-        let hash = hasher.hash(&preimage.to_bits_le())?.to_string();
-        if hash == raw_blockid {
-            let block = Block::from_bytes_le(raw_block0)?;
-            return Ok(block);
-        }
-
-        // A closure to load the block.
-        let load_block = |file_path| -> Result<Block<N>> {
-            // Attempts to load the genesis block file locally.
-            let buffer = std::fs::read(file_path)?;
-            // Return the genesis block.
-            Block::from_bytes_le(&buffer)
-        };
-
-        // Construct the file path.
-        let file_path = std::env::temp_dir().join(hash);
-
-        // Check if the genesis block exists.
-        if file_path.exists() {
-            // If the block loads successfully, return it.
-            if let Ok(block) = load_block(&file_path) {
-                return Ok(block);
-            }
-        }
-
-        /* Otherwise, compute the genesis block and store it. */
-
-        // Initialize a new VM.
-        let vm = VM::from(ConsensusStore::<N, ConsensusMemory<N>>::open(0u16)?)?;
-        // Initialize the genesis block.
-        let block = vm.genesis_quorum(&genesis_private_key, committee, public_balances, bonded_balances, rng)?;
-        // Write the genesis block to the file.
-        std::fs::write(&file_path, block.to_bytes_le()?)?;
-        // Return the genesis block.
-        Ok(block)
+        data.validator = ValidatorApi::None;
+        data.prev_state = data.state;
+        data.state = AmareleoApiState::Stopped;
     }
 }

--- a/api/src/api/api_state.rs
+++ b/api/src/api/api_state.rs
@@ -1,0 +1,103 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// AmareleoApi object state enumeration
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AmareleoApiState {
+    /// Node instance created and is fully configurable.
+    /// - State entered on successfully calling `new()` for the first time.
+    ///
+    /// - Allowed function calls:
+    ///     - Config getters: `get_*()` and `is_*()`
+    ///     - Config setters: `cfg_*()` and `try_cfg_*()`
+    ///     - Node starting: `start()`
+    ///
+    /// - State transitions from `Init`:
+    ///     - Config getters: `Init -> Init`
+    ///     - Config setters: `Init -> Init`
+    ///     - `start()`: `Init -> StartPending -> Started`
+    Init,
+
+    /// Node configuration is completely locked and node is
+    /// ready to start.
+    ///
+    /// This is an intermediate internal state the node goes
+    /// through when `start()` is called. However this is not
+    /// the final state resulting from calling `start()`. Thus
+    /// unless one polls the node state while `start()` is
+    /// running, this state may be difficult to detect.
+    ///
+    /// - State entered on successfully calling `start()`
+    ///
+    /// - Allowed function calls:
+    ///     - Config getters: `get_*()` and `is_*()`
+    ///
+    /// - State transitions from `StartPending`:
+    ///     - Config getters: `StartPending -> StartPending`
+    ///     - `start()`: `StartPending -> Started`
+    StartPending,
+
+    /// Node configuration is completely locked and node is
+    /// running.
+    ///
+    /// This is the final node state after successfully running
+    /// `start()`
+    ///
+    /// - State entered on successfully calling `start()`
+    ///
+    /// - Allowed function calls:
+    ///     - Config getters: `get_*()` and `is_*()`
+    ///     - Node stopping: `end()`
+    ///
+    /// - State transitions from `Started`:
+    ///     - Config getters: `Started -> Started`
+    ///     - `end()`: `Started -> StopPending -> Stopped`
+    Started,
+
+    /// Node configuration is completely locked and node is
+    /// ready to stop.
+    ///
+    /// This is an intermediate internal state the node goes
+    /// through when `end()` is called. However this is not
+    /// the final state resulting from calling `end()`. Thus
+    /// unless one polls the node state while `end()` is
+    /// running, this state may be difficult to detect.
+    ///
+    /// - State entered on successfully calling `end()`
+    ///
+    /// - Allowed function calls:
+    ///     - Config getters: `get_*()` and `is_*()`
+    ///
+    /// - State transitions from `StopPending`:
+    ///     - Config getters: `StopPending -> StopPending`
+    ///     - `end()`: `StopPending -> Stopped`
+    StopPending,
+
+    /// Node configuration is __partially__ locked and node is
+    /// stopped.
+    ///
+    /// This is the final node state after successfully running
+    /// `end()`
+    ///
+    /// - State entered on successfully calling `end()`
+    ///
+    /// - Allowed function calls:
+    ///     - Config getters: `get_*()` and `is_*()`
+    ///     - Subset of config setters: `cfg_*()` and `try_cfg_*()`
+    ///     - Node starting: `start()`
+    ///
+    /// - State transitions from `Stopped`:
+    ///     - Config getters: `Stopped -> Stopped`
+    ///     - Config setters: `Stopped -> Stopped`
+    ///     - `start()`: `Stopped -> StartPending -> Started`
+    Stopped,
+}

--- a/api/src/api/api_tests.rs
+++ b/api/src/api/api_tests.rs
@@ -12,51 +12,130 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::api_node::AmareleoApi;
+    use crate::{AmareleoApiState, api_node::AmareleoApi};
+    use amareleo_chain_tracing::TracingHandler;
     use serial_test::serial;
+    use snarkvm::prelude::{MainnetV0, Network};
 
-    #[tokio::test]
+    #[test]
     #[serial]
-    async fn test_node_ledger_path_conflict() {
-        let temp_path = std::env::temp_dir();
+    fn test_singleton_reference_identity() {
+        let instance1 = AmareleoApi::new();
+        let instance2 = AmareleoApi::new();
 
-        // Configure first node on port 3030
-        let mut node1 = AmareleoApi::default();
-        node1.cfg_ledger(false, Some(temp_path.clone()), false).cfg_rest("127.0.0.1:3030".parse().unwrap(), 10);
-
-        // Start and end the first node
-        assert!(node1.start().await.is_ok());
-        node1.end().await;
-
-        // Configure second node on port 3031
-        let mut node2 = AmareleoApi::default();
-        node2.cfg_ledger(false, Some(temp_path.clone()), false).cfg_rest("127.0.0.1:3031".parse().unwrap(), 10);
-
-        // Starting the node fails due to snarkVM restriction described here:
-        // https://github.com/kaxxa123/amareleo-chain/issues/19
-        assert!(node2.start().await.is_err());
-        node2.end().await;
+        // Check that both references point to the same memory address
+        assert!(std::ptr::eq(instance1, instance2), "Singleton returned different references!");
     }
 
     #[tokio::test]
     #[serial]
-    async fn test_node_restart() {
+    async fn test_node_state() {
         let temp_path = std::env::temp_dir();
 
-        // Configure node on port 3030
-        let mut node1 = AmareleoApi::default();
-        node1.cfg_ledger(false, Some(temp_path.clone()), false).cfg_rest("127.0.0.1:3030".parse().unwrap(), 10);
+        // Test setters
+        // Configure first node on port 3030
+        let node1 = AmareleoApi::new();
+        assert!(node1.cfg_network(MainnetV0::ID).is_ok());
+        assert!(node1.cfg_ledger(false, Some(temp_path.clone()), true).is_ok());
+        assert!(node1.cfg_rest("127.0.0.1:3030".parse().unwrap(), 10).is_ok());
+        assert!(node1.cfg_file_log(None, 4).is_ok());
+        assert!(node1.cfg_custom_log(TracingHandler::new()).is_ok());
+        assert!(node1.cfg_no_log().is_ok());
+        //======================================
 
-        // Start and end the node
+        // Test getters
+        assert!(!node1.is_started());
+        assert!(node1.get_log_file().is_err());
+
+        // Well known ledger path when:
+        // - base path is set manually
+        // - default naming enabled
+        // - MainnetV0
+        let ledger = node1.get_ledger_folder();
+        assert!(ledger.is_ok());
+
+        let ledger = ledger.unwrap();
+        let mut expected = temp_path.clone();
+        expected.push(".amareleo-tmp-ledger-0-0");
+        assert_eq!(ledger, expected);
+        //======================================
+
+        // Start node
+        assert!(node1.get_state() == AmareleoApiState::Init);
         assert!(node1.start().await.is_ok());
-        node1.end().await;
+        //======================================
 
-        // Restart the node with the exact same settings...
-        let mut node2 = AmareleoApi::default();
-        node2.cfg_ledger(false, Some(temp_path.clone()), false).cfg_rest("127.0.0.1:3030".parse().unwrap(), 10);
+        // Test setters
+        // Once started config is locked completely
+        assert!(node1.cfg_network(MainnetV0::ID).is_err());
+        assert!(node1.cfg_ledger(false, Some(temp_path.clone()), true).is_err());
+        assert!(node1.cfg_rest("127.0.0.1:3031".parse().unwrap(), 10).is_err());
+        assert!(node1.cfg_file_log(None, 4).is_err());
+        assert!(node1.cfg_custom_log(TracingHandler::new()).is_err());
+        assert!(node1.cfg_no_log().is_err());
+        //======================================
 
-        // Start and end the node
+        // Test getters
+        assert!(node1.is_started());
+        //======================================
+
+        // Stop node
+        assert!(node1.get_state() == AmareleoApiState::Started);
+        assert!(node1.end().await.is_ok());
+        //======================================
+
+        // Calling new will return the same instance.
+        // We call this as another confirmation that we are working with a singleton.
+        let node2 = AmareleoApi::new();
+
+        // Test setters
+        // Some config properties cannot ever change after
+        // the first start even if stopped...
+        assert!(node2.cfg_network(MainnetV0::ID).is_err());
+        assert!(node2.cfg_ledger(false, Some(temp_path.clone()), false).is_err());
+        assert!(node2.cfg_rest("127.0.0.1:3031".parse().unwrap(), 10).is_err());
+
+        // Some config properties can still change
+        assert!(node2.cfg_custom_log(TracingHandler::new()).is_ok());
+        assert!(node2.cfg_no_log().is_ok());
+        assert!(node2.cfg_file_log(None, 4).is_ok());
+        //======================================
+
+        // Test getters
+        assert!(!node2.is_started());
+
+        // Well known default log file path when:
+        // - NOT keeping staate,
+        // - MainnetV0
+        // - REST 127.0.0.1:3030
+        let logfile = node2.get_log_file();
+        assert!(logfile.is_ok());
+
+        let logfile = logfile.unwrap();
+        let mut expected = temp_path.clone();
+        expected.push("amareleo-chain-tmp-0-8e4fb233.log");
+        assert_eq!(logfile, expected);
+
+        // Well known ledger path when:
+        // - base path is set manually
+        // - default naming enabled
+        // - MainnetV0
+        let ledger = node2.get_ledger_folder();
+        assert!(ledger.is_ok());
+
+        let ledger = ledger.unwrap();
+        let mut expected = temp_path.clone();
+        expected.push(".amareleo-tmp-ledger-0-0");
+        assert_eq!(ledger, expected);
+        //======================================
+
+        // Re-start the node
+        assert!(node2.get_state() == AmareleoApiState::Stopped);
         assert!(node2.start().await.is_ok());
-        node2.end().await;
+
+        assert!(node2.get_state() == AmareleoApiState::Started);
+        assert!(node2.end().await.is_ok());
+
+        assert!(node2.get_state() == AmareleoApiState::Stopped);
     }
 }

--- a/api/src/api/api_tests.rs
+++ b/api/src/api/api_tests.rs
@@ -12,11 +12,8 @@
 
 #[cfg(test)]
 mod tests {
-
     use crate::api_node::AmareleoApi;
     use serial_test::serial;
-    use snarkvm::prelude::TestnetV0;
-    type CurrentNetwork = TestnetV0;
 
     #[tokio::test]
     #[serial]
@@ -24,7 +21,7 @@ mod tests {
         let temp_path = std::env::temp_dir();
 
         // Configure first node on port 3030
-        let mut node1: AmareleoApi<CurrentNetwork> = AmareleoApi::default();
+        let mut node1 = AmareleoApi::default();
         node1.cfg_ledger(false, Some(temp_path.clone()), false).cfg_rest("127.0.0.1:3030".parse().unwrap(), 10);
 
         // Start and end the first node
@@ -32,7 +29,7 @@ mod tests {
         node1.end().await;
 
         // Configure second node on port 3031
-        let mut node2: AmareleoApi<CurrentNetwork> = AmareleoApi::default();
+        let mut node2 = AmareleoApi::default();
         node2.cfg_ledger(false, Some(temp_path.clone()), false).cfg_rest("127.0.0.1:3031".parse().unwrap(), 10);
 
         // Starting the node fails due to snarkVM restriction described here:
@@ -47,7 +44,7 @@ mod tests {
         let temp_path = std::env::temp_dir();
 
         // Configure node on port 3030
-        let mut node1: AmareleoApi<CurrentNetwork> = AmareleoApi::default();
+        let mut node1 = AmareleoApi::default();
         node1.cfg_ledger(false, Some(temp_path.clone()), false).cfg_rest("127.0.0.1:3030".parse().unwrap(), 10);
 
         // Start and end the node
@@ -55,7 +52,7 @@ mod tests {
         node1.end().await;
 
         // Restart the node with the exact same settings...
-        let mut node2: AmareleoApi<CurrentNetwork> = AmareleoApi::default();
+        let mut node2 = AmareleoApi::default();
         node2.cfg_ledger(false, Some(temp_path.clone()), false).cfg_rest("127.0.0.1:3030".parse().unwrap(), 10);
 
         // Start and end the node

--- a/api/src/api/api_validator.rs
+++ b/api/src/api/api_validator.rs
@@ -1,0 +1,109 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use crate::AmareleoApi;
+
+use std::{
+    net::SocketAddr,
+    sync::{Arc, atomic::AtomicBool},
+};
+
+use aleo_std::StorageMode;
+
+use snarkvm::{
+    console::network::{CanaryV0, MainnetV0, Network, TestnetV0},
+    ledger::store::helpers::rocksdb::ConsensusDB,
+};
+
+use anyhow::{Result, bail};
+
+use amareleo_chain_tracing::TracingHandler;
+use amareleo_node::Validator;
+
+// Enumeration helping handling of Validator instances without
+// the need for geeneric type parameters.
+pub(crate) enum ValidatorApi {
+    CanaryV0(Validator<CanaryV0, ConsensusDB<CanaryV0>>),
+    MainnetV0(Validator<MainnetV0, ConsensusDB<MainnetV0>>),
+    TestnetV0(Validator<TestnetV0, ConsensusDB<TestnetV0>>),
+    None,
+}
+
+impl ValidatorApi {
+    pub async fn new(
+        network_id: u16,
+        rest_ip: SocketAddr,
+        rest_rps: u32,
+        keep_state: bool,
+        storage_mode: StorageMode,
+        log_trace: Option<TracingHandler>,
+        shutdown: Arc<AtomicBool>,
+    ) -> Result<Self> {
+        match network_id {
+            CanaryV0::ID => {
+                let validator = Validator::<CanaryV0, ConsensusDB<CanaryV0>>::new(
+                    rest_ip,
+                    rest_rps,
+                    AmareleoApi::get_node_account::<CanaryV0>()?,
+                    AmareleoApi::get_genesis::<CanaryV0>()?,
+                    keep_state,
+                    storage_mode,
+                    log_trace,
+                    shutdown,
+                )
+                .await?;
+                Ok(ValidatorApi::CanaryV0(validator))
+            }
+            TestnetV0::ID => {
+                let validator = Validator::<TestnetV0, ConsensusDB<TestnetV0>>::new(
+                    rest_ip,
+                    rest_rps,
+                    AmareleoApi::get_node_account::<TestnetV0>()?,
+                    AmareleoApi::get_genesis::<TestnetV0>()?,
+                    keep_state,
+                    storage_mode,
+                    log_trace,
+                    shutdown,
+                )
+                .await?;
+                Ok(ValidatorApi::TestnetV0(validator))
+            }
+            MainnetV0::ID => {
+                let validator = Validator::<MainnetV0, ConsensusDB<MainnetV0>>::new(
+                    rest_ip,
+                    rest_rps,
+                    AmareleoApi::get_node_account::<MainnetV0>()?,
+                    AmareleoApi::get_genesis::<MainnetV0>()?,
+                    keep_state,
+                    storage_mode,
+                    log_trace,
+                    shutdown,
+                )
+                .await?;
+                Ok(ValidatorApi::MainnetV0(validator))
+            }
+            _ => bail!("Unsupported network ID"),
+        }
+    }
+
+    pub async fn shut_down(&self) {
+        match self {
+            ValidatorApi::CanaryV0(validator) => validator.shut_down().await,
+            ValidatorApi::TestnetV0(validator) => validator.shut_down().await,
+            ValidatorApi::MainnetV0(validator) => validator.shut_down().await,
+            ValidatorApi::None => (),
+        }
+    }
+
+    pub fn is_started(&self) -> bool {
+        !matches!(self, ValidatorApi::None)
+    }
+}

--- a/api/src/api/api_validator.rs
+++ b/api/src/api/api_validator.rs
@@ -9,7 +9,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use crate::AmareleoApi;
+
+use crate::{get_genesis, get_node_account};
 
 use std::{
     net::SocketAddr,
@@ -23,13 +24,14 @@ use snarkvm::{
     ledger::store::helpers::rocksdb::ConsensusDB,
 };
 
-use anyhow::{Result, bail};
+use anyhow::{Ok, Result, bail};
 
 use amareleo_chain_tracing::TracingHandler;
 use amareleo_node::Validator;
 
-// Enumeration helping handling of Validator instances without
-// the need for geeneric type parameters.
+// Enumeration helping AmareleoApi to handle a Validator
+// instances without the need for generic type parameters.
+#[derive(Clone)]
 pub(crate) enum ValidatorApi {
     CanaryV0(Validator<CanaryV0, ConsensusDB<CanaryV0>>),
     MainnetV0(Validator<MainnetV0, ConsensusDB<MainnetV0>>),
@@ -37,55 +39,58 @@ pub(crate) enum ValidatorApi {
     None,
 }
 
+#[derive(Clone)]
+pub(crate) struct ValidatorNewData {
+    pub network_id: u16,
+    pub rest_ip: SocketAddr,
+    pub rest_rps: u32,
+    pub keep_state: bool,
+    pub storage_mode: StorageMode,
+    pub tracing: Option<TracingHandler>,
+    pub shutdown: Arc<AtomicBool>,
+}
+
 impl ValidatorApi {
-    pub async fn new(
-        network_id: u16,
-        rest_ip: SocketAddr,
-        rest_rps: u32,
-        keep_state: bool,
-        storage_mode: StorageMode,
-        log_trace: Option<TracingHandler>,
-        shutdown: Arc<AtomicBool>,
-    ) -> Result<Self> {
-        match network_id {
+    pub async fn new(data: ValidatorNewData) -> Result<Self> {
+        match data.network_id {
             CanaryV0::ID => {
                 let validator = Validator::<CanaryV0, ConsensusDB<CanaryV0>>::new(
-                    rest_ip,
-                    rest_rps,
-                    AmareleoApi::get_node_account::<CanaryV0>()?,
-                    AmareleoApi::get_genesis::<CanaryV0>()?,
-                    keep_state,
-                    storage_mode,
-                    log_trace,
-                    shutdown,
+                    data.rest_ip,
+                    data.rest_rps,
+                    get_node_account::<CanaryV0>()?,
+                    get_genesis::<CanaryV0>()?,
+                    data.keep_state,
+                    data.storage_mode,
+                    data.tracing,
+                    data.shutdown,
                 )
                 .await?;
                 Ok(ValidatorApi::CanaryV0(validator))
             }
             TestnetV0::ID => {
                 let validator = Validator::<TestnetV0, ConsensusDB<TestnetV0>>::new(
-                    rest_ip,
-                    rest_rps,
-                    AmareleoApi::get_node_account::<TestnetV0>()?,
-                    AmareleoApi::get_genesis::<TestnetV0>()?,
-                    keep_state,
-                    storage_mode,
-                    log_trace,
-                    shutdown,
+                    data.rest_ip,
+                    data.rest_rps,
+                    get_node_account::<TestnetV0>()?,
+                    get_genesis::<TestnetV0>()?,
+                    data.keep_state,
+                    data.storage_mode,
+                    data.tracing,
+                    data.shutdown,
                 )
                 .await?;
                 Ok(ValidatorApi::TestnetV0(validator))
             }
             MainnetV0::ID => {
                 let validator = Validator::<MainnetV0, ConsensusDB<MainnetV0>>::new(
-                    rest_ip,
-                    rest_rps,
-                    AmareleoApi::get_node_account::<MainnetV0>()?,
-                    AmareleoApi::get_genesis::<MainnetV0>()?,
-                    keep_state,
-                    storage_mode,
-                    log_trace,
-                    shutdown,
+                    data.rest_ip,
+                    data.rest_rps,
+                    get_node_account::<MainnetV0>()?,
+                    get_genesis::<MainnetV0>()?,
+                    data.keep_state,
+                    data.storage_mode,
+                    data.tracing,
+                    data.shutdown,
                 )
                 .await?;
                 Ok(ValidatorApi::MainnetV0(validator))
@@ -101,9 +106,5 @@ impl ValidatorApi {
             ValidatorApi::MainnetV0(validator) => validator.shut_down().await,
             ValidatorApi::None => (),
         }
-    }
-
-    pub fn is_started(&self) -> bool {
-        !matches!(self, ValidatorApi::None)
     }
 }

--- a/api/src/api/mod.rs
+++ b/api/src/api/mod.rs
@@ -18,3 +18,6 @@ pub mod api_node;
 
 pub use api_logs::*;
 pub mod api_logs;
+
+pub(crate) use api_validator::*;
+pub(crate) mod api_validator;

--- a/api/src/api/mod.rs
+++ b/api/src/api/mod.rs
@@ -19,5 +19,14 @@ pub mod api_node;
 pub use api_logs::*;
 pub mod api_logs;
 
+pub use api_state::*;
+pub mod api_state;
+
+pub use api_helpers::*;
+pub mod api_helpers;
+
 pub(crate) use api_validator::*;
 pub(crate) mod api_validator;
+
+pub(crate) use api_data::*;
+pub(crate) mod api_data;

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -29,7 +29,7 @@ use tokio::runtime::{self, Runtime};
 use snarkvm::console::network::{CanaryV0, MainnetV0, Network, TestnetV0};
 
 use crate::helpers::initialize_custom_tracing;
-use amareleo_chain_api::AmareleoApi;
+use amareleo_chain_api::{AmareleoApi, get_node_account};
 
 /// Starts the node.
 #[derive(Clone, Debug, Parser)]
@@ -81,19 +81,16 @@ impl Start {
             // Parse the network.
             match cli.network {
                 MainnetV0::ID => {
-                    let node_api =
-                        cli.start_node::<MainnetV0>(shutdown.clone()).await.expect("Failed to parse the node");
-                    cli.handle_termination(node_api, shutdown);
+                    cli.start_node::<MainnetV0>(shutdown.clone()).await.expect("Failed to parse the node");
+                    cli.handle_termination(shutdown);
                 }
                 TestnetV0::ID => {
-                    let node_api =
-                        cli.start_node::<TestnetV0>(shutdown.clone()).await.expect("Failed to parse the node");
-                    cli.handle_termination(node_api, shutdown);
+                    cli.start_node::<TestnetV0>(shutdown.clone()).await.expect("Failed to parse the node");
+                    cli.handle_termination(shutdown);
                 }
                 CanaryV0::ID => {
-                    let node_api =
-                        cli.start_node::<CanaryV0>(shutdown.clone()).await.expect("Failed to parse the node");
-                    cli.handle_termination(node_api, shutdown);
+                    cli.start_node::<CanaryV0>(shutdown.clone()).await.expect("Failed to parse the node");
+                    cli.handle_termination(shutdown);
                 }
                 _ => panic!("Invalid network ID specified"),
             };
@@ -107,7 +104,7 @@ impl Start {
 
     /// Returns the node type corresponding to the given configurations.
     #[rustfmt::skip]
-    async fn start_node<N: Network>(&mut self, shutdown: Arc<AtomicBool>) -> Result<AmareleoApi> {
+    async fn start_node<N: Network>(&mut self, shutdown: Arc<AtomicBool>) -> Result<()> {
 
         // Print the welcome.
         println!("{}", Self::welcome_message());
@@ -116,7 +113,7 @@ impl Start {
         let rest_ip_port = self.rest.as_ref().copied().unwrap_or_else(|| "0.0.0.0:3030".parse().unwrap());
 
         // Get the node account.
-        let account = AmareleoApi::get_node_account::<N>()?;
+        let account = get_node_account::<N>()?;
         println!("🔑 Your development private key for node 0 is {}.\n", account.private_key().to_string().bold());
         println!("👛 Your Aleo address is {}.\n", account.address().to_string().bold());
         println!("🧭 Starting node on {}.\n",N::NAME.bold());
@@ -132,16 +129,16 @@ impl Start {
             metrics::initialize_metrics(self.metrics_ip);
         }
 
-        let mut node_api= AmareleoApi::default();
+        let node_api= AmareleoApi::new();
 
         // Configure the node api including file logging.
         // We only include file logging for us to easily get the log file path.
         // Ultimately we opt for custom logging.
         node_api
-        .cfg_network_id(N::ID)
-        .cfg_ledger(self.keep_state, self.storage.clone(), self.keep_state)
-        .cfg_rest(rest_ip_port, self.rest_rps)
-        .cfg_file_log(self.logfile.clone(), self.verbosity);
+        .try_cfg_network(N::ID)
+        .try_cfg_ledger(self.keep_state, self.storage.clone(), self.keep_state)
+        .try_cfg_rest(rest_ip_port, self.rest_rps)
+        .cfg_file_log(self.logfile.clone(), self.verbosity)?;
 
         // Get the log file path and setup custom logging.
         let logfile_path = node_api.get_log_file()?;
@@ -150,18 +147,18 @@ impl Start {
             logfile_path.clone(),
             shutdown)?;
 
-        node_api.cfg_custom_log(tracing);
+        node_api.cfg_custom_log(tracing)?;
 
         println!("📝 Log file path: {}\n", logfile_path.to_string_lossy());
         println!("📁 Ledger folder path: {}\n", node_api.get_ledger_folder()?.to_string_lossy());
 
-        // Initialize the node.
+        // Start the node.
         node_api.start().await?;
-        Ok(node_api)
+        Ok(())
     }
 
     /// Handles OS signals for intercept termination and performing a clean shutdown.
-    fn handle_termination(&self, mut node_api: AmareleoApi, shutdown: Arc<AtomicBool>) {
+    fn handle_termination(&self, shutdown: Arc<AtomicBool>) {
         #[cfg(target_family = "unix")]
         fn signal_listener() -> impl Future<Output = std::io::Result<()>> {
             use tokio::signal::unix::{SignalKind, signal};
@@ -189,7 +186,6 @@ impl Start {
         }
 
         let keep_state = self.keep_state;
-
         tokio::task::spawn(async move {
             match signal_listener().await {
                 Ok(()) => {
@@ -215,7 +211,8 @@ impl Start {
                     shutdown.store(true, std::sync::atomic::Ordering::Relaxed);
 
                     // Shut down the node.
-                    node_api.end().await;
+                    // AmareleoApi is a sigleton, so we can grab a reference to it with new()
+                    let _ = AmareleoApi::new().end().await;
 
                     // Terminate the process.
                     std::process::exit(0);

--- a/node/bft/src/helpers/ledger_files.rs
+++ b/node/bft/src/helpers/ledger_files.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use snarkvm::{
-    console::{algorithms::Hash, network::Network},
+    console::{algorithms::Hash, network::MainnetV0},
     prelude::{Result, ToBits, ToBytes, anyhow, bail},
 };
 
@@ -31,7 +31,7 @@ const LOG_TMP_FILE: &str = "amareleo-chain-tmp";
 pub const DEFAULT_FILE_TAG: &str = "0";
 
 /// A string derived from the hash of the REST endpoint, giving us a unique filename per endpoint.
-pub fn endpoint_file_tag<N: Network>(force_default: bool, endpoint: &SocketAddr) -> Result<String> {
+pub fn endpoint_file_tag(force_default: bool, endpoint: &SocketAddr) -> Result<String> {
     if force_default {
         return Ok(DEFAULT_FILE_TAG.to_string());
     }
@@ -42,7 +42,7 @@ pub fn endpoint_file_tag<N: Network>(force_default: bool, endpoint: &SocketAddr)
     }
 
     // Initialize the hasher.
-    let hasher = snarkvm::console::algorithms::BHP256::<N>::setup("aleo.dev.block")?;
+    let hasher = snarkvm::console::algorithms::BHP256::<MainnetV0>::setup("aleo.dev.block")?;
     let endpoint_str = endpoint.to_string();
     let bits = endpoint_str.to_bits_le();
     let hash = hasher.hash(&bits)?.to_bytes_le()?;


### PR DESCRIPTION
Given issue #19 `AmareleoApi` is now a singleton driven by a state engine defined in `AmareleoApiState`. 

This restricts when and which configuration parameters can be modified based on the current node state. 

The restrictions take into account the fact that users cannot change the ledger folder path and the network id once the node is started for the first time.
