### PR TITLE
ci-api: attempting circleci fix when testing api

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,6 +206,7 @@ jobs:
       - run_serial:
           workspace_member: api
           cache_key: v3.0.0-rust-1.83.0-api-cache
+          flags: "--release --lib"
 
   node:
     docker:


### PR DESCRIPTION
attempting circleci fix when testing api by adding `--release --lib` flags to `cargo test`